### PR TITLE
Add prompt tool fallback for web-synced models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ omni
 
 Chat-only models should use prompt-emulated tools automatically when:
 
-- model id/name/provider contains `-web`
+- model id/name/provider or OmniRoute `owned_by` contains `-web`
 - or raw `models.json` model entry has `tool_calling:false`
 
 Do not rely only on Pi runtime `Model` for custom metadata. Pi strips unknown fields; use raw `models.json` when needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md
+
+Instructions for AI agents working in this repository.
+
+## Start Here
+
+Before editing, read:
+
+1. `AI.md` — fast project handoff and key function map.
+2. `ARCHITECTURE.md` — extension data flow and prompt-tool design.
+3. `README.md` — user-facing behavior and commands.
+4. `CONTRIBUTING.md` — local checks and contribution rules.
+
+## Must-Do Documentation Rule
+
+If you change source behavior, update docs in the same change.
+
+Use this mapping:
+
+| Change type | Docs to update |
+|---|---|
+| User-visible command/setup/model behavior | `README.md` |
+| Provider flow, tool routing, prompt-tool logic | `ARCHITECTURE.md` |
+| File layout, key function names, scan paths, pitfalls | `AI.md` |
+| Dev workflow, tests, contribution process | `CONTRIBUTING.md` |
+| Package scripts/deps | `README.md` Development section and `CONTRIBUTING.md` if relevant |
+
+Do not leave code/docs inconsistent.
+
+## Core UX Constraint
+
+Keep model switching normal:
+
+```text
+/model <model-id>
+```
+
+Do not introduce duplicate providers or separate manual prompt-tool model lists unless user explicitly asks.
+
+The provider should remain:
+
+```text
+omni
+```
+
+## Prompt Tool Constraint
+
+Chat-only models should use prompt-emulated tools automatically when:
+
+- model id/name/provider contains `-web`
+- or raw `models.json` model entry has `tool_calling:false`
+
+Do not rely only on Pi runtime `Model` for custom metadata. Pi strips unknown fields; use raw `models.json` when needed.
+
+## Test Before Reporting Done
+
+Run:
+
+```bash
+npm run typecheck
+npm run smoke
+```
+
+If tests cannot run, report exact command and failure.
+
+## Edit Guidance
+
+- Prefer small targeted edits.
+- Keep comments on non-obvious functions.
+- Preserve `/omni setup`, `/omni sync`, `/omni dashboard` behavior unless user asks to change it.
+- Keep prompt-tool format and parser docs in sync.
+- If adding files, update `AI.md` file map.
+
+## Important Files
+
+| File | Why important |
+|---|---|
+| `index.ts` | Extension implementation. |
+| `AI.md` | AI scan guide; update when project structure/function map changes. |
+| `ARCHITECTURE.md` | Data flow and tool routing docs. |
+| `README.md` | User-facing documentation. |
+| `CONTRIBUTING.md` | Dev/test workflow. |
+| `package.json` | Pi extension metadata and scripts. |

--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,195 @@
+# AI Handoff Guide
+
+This file is the first stop for AI agents. Read this before scanning the repo.
+
+## Repository Purpose
+
+`omniroute-pi-ext-integration` is a Pi Coding Agent extension for OmniRoute.
+
+It does three jobs:
+
+1. `/omni setup` saves OmniRoute URL/API key into Pi `models.json`.
+2. `/omni sync` fetches OmniRoute `/v1/models` and syncs them into Pi's `/model` picker.
+3. The extension registers an `omni` provider that routes tool calling automatically:
+   - native tool-capable models use OpenAI-compatible native `tool_calls`
+   - chat-only models use prompt-emulated tools via `<tool_call>` blocks
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `index.ts` | Entire extension implementation. Commands, sync, provider registration, prompt-tool fallback. |
+| `README.md` | User-facing install/setup/usage docs. |
+| `package.json` | Pi extension metadata, scripts, dev deps. |
+| `package-lock.json` | Locked npm dependency tree. |
+| `AGENTS.md` | Mandatory instructions for AI agents editing this repo. |
+| `ARCHITECTURE.md` | Detailed data flow and prompt-tool architecture. |
+| `CONTRIBUTING.md` | Dev workflow, test checklist, and contribution rules. |
+| `LICENSE` | MIT license. |
+
+## Key Concepts
+
+### Provider name
+
+The Pi provider is always:
+
+```text
+omni
+```
+
+Users keep switching models normally:
+
+```text
+/model cgpt-web/gpt-5.4-pro
+/model codex/gpt-5.2
+```
+
+Do not create a second prompt-tools provider unless explicitly requested.
+
+### Custom API id
+
+The extension registers a synthetic API id:
+
+```ts
+const OMNI_PROMPT_TOOLS_API = "omni-prompt-tools";
+```
+
+That custom API routes through `streamOmni()`.
+
+### Underlying API
+
+Real HTTP calls still use Pi's built-in OpenAI-compatible provider:
+
+```ts
+const UNDERLYING_API = "openai-completions";
+```
+
+Native mode passes tools normally. Prompt mode strips native tools and renders tool schemas as text.
+
+## Tool Mode Decision
+
+Entry point:
+
+```ts
+shouldUsePromptTools(model)
+```
+
+Prompt tool mode triggers when:
+
+1. raw `models.json` says the selected model has:
+
+```json
+"tool_calling": false
+```
+
+2. or model id/name/provider contains:
+
+```text
+-web
+```
+
+Reason: Pi's runtime `Model` type does not preserve custom fields like `tool_calling`, so the extension re-reads raw `models.json` in `modelConfigToolCallingFalse()`.
+
+## Important Functions In `index.ts`
+
+Read in this order:
+
+1. `registerOmniProvider()` — registers/refreshes the `omni` provider and model list.
+2. `streamOmni()` — runtime router for native vs prompt tool mode.
+3. `shouldUsePromptTools()` — decides if prompt tool fallback is needed.
+4. `streamWithPromptTools()` — prompt-tool stream implementation.
+5. `renderToolProtocol()` — converts Pi tool schemas into prompt text.
+6. `flattenMessages()` — converts native tool history into text history for chat-only models.
+7. `parseToolCalls()` — parses `<tool_call>` blocks from model output.
+8. `getAllModelsFromOmniRoute()` — fetches `/v1/models` and converts to Pi model entries.
+9. `humanName()` — user-friendly labels for Ctrl+P.
+
+## Prompt Tool Wire Format
+
+The chat-only model is instructed to emit:
+
+```xml
+<tool_call>
+{"name":"read","arguments":{"path":"index.ts"}}
+</tool_call>
+```
+
+Tool results are replayed in history as:
+
+```xml
+<tool_result tool="read" id="call_123">
+...tool output...
+</tool_result>
+```
+
+`streamWithPromptTools()` parses these text blocks and emits Pi native `toolcall_*` stream events so Pi executes tools normally.
+
+## Common Change Requests
+
+### Add a new model detection rule
+
+Update:
+
+```ts
+shouldUsePromptTools()
+```
+
+Keep `modelConfigToolCallingFalse()` because raw `models.json` metadata is important.
+
+### Change OmniRoute sync metadata
+
+Update:
+
+```ts
+getAllModelsFromOmniRoute()
+SyncedModel
+```
+
+Then update README example model JSON if user-visible.
+
+### Change prompt tool format
+
+Update together:
+
+```ts
+renderToolProtocol()
+TOOL_CALL_RE
+renderToolCallBlock()
+parseToolCalls()
+README.md
+```
+
+### Change setup behavior
+
+Update `/omni setup` handler near bottom of `index.ts`.
+
+### Change sync behavior
+
+Update `/omni sync` handler and `getAllModelsFromOmniRoute()`.
+
+## Test Commands
+
+```bash
+npm run typecheck
+npm run smoke
+```
+
+Expected smoke output:
+
+```text
+import ok
+```
+
+## Pitfalls
+
+- Do not rely only on Pi runtime `Model` for `tool_calling`; custom fields are stripped.
+- Do not set web/chat-only models to a separate provider; keep `/model` workflow unchanged.
+- Do not send native `tools` to chat-only web-synced models; use prompt mode with `tools: []`.
+- `streamWithPromptTools()` is buffered, not token-streamed. It waits for full response so it can parse tool blocks safely.
+- Prompt mode drops non-text content in history because chat-only OpenAI-compatible endpoints here are treated as text-first.
+
+## Current Branch Intent
+
+Branch `prompt-tools-web-fallback` adds prompt-emulated tool calling inside the existing OmniRoute extension.
+
+Goal: no UX change for user. `/model` works same; extension chooses tool mode internally.

--- a/AI.md
+++ b/AI.md
@@ -82,7 +82,7 @@ Prompt tool mode triggers when:
 "tool_calling": false
 ```
 
-2. or model id/name/provider contains:
+2. or model id/name/provider/OmniRoute `owned_by` contains:
 
 ```text
 -web
@@ -182,7 +182,7 @@ import ok
 
 ## Pitfalls
 
-- Do not rely only on Pi runtime `Model` for `tool_calling`; custom fields are stripped.
+- Do not rely only on Pi runtime `Model` for `tool_calling`; custom fields and OmniRoute `owned_by` are stripped.
 - Do not set web/chat-only models to a separate provider; keep `/model` workflow unchanged.
 - Do not send native `tools` to chat-only web-synced models; use prompt mode with `tools: []`.
 - `streamWithPromptTools()` is buffered, not token-streamed. It waits for full response so it can parse tool blocks safely.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,155 @@
+# Architecture
+
+## Overview
+
+This extension is a single-file Pi extension (`index.ts`) that integrates OmniRoute with Pi Coding Agent.
+
+```text
+Pi CLI
+  -> loads extension from package.json pi.extensions
+  -> extension registers /omni command
+  -> extension registers omni provider
+  -> user selects models with /model
+  -> streamOmni() chooses native tools or prompt tools per selected model
+```
+
+## Data Flow: Setup
+
+```text
+/omni setup
+  -> ask user for OmniRoute URL
+  -> verify URL with GET /v1/models
+  -> ask user for API key
+  -> write ~/.pi/agent/models.json
+  -> register/refresh omni provider
+```
+
+Saved provider shape:
+
+```json
+{
+  "providers": {
+    "omni": {
+      "baseUrl": "https://example.com",
+      "api": "omni-prompt-tools",
+      "apiKey": "...",
+      "models": []
+    }
+  }
+}
+```
+
+## Data Flow: Sync
+
+```text
+/omni sync
+  -> GET {OMNI_URL}/v1/models
+  -> filter non-chat/image-only models
+  -> normalize input modalities
+  -> copy context/max token/reasoning metadata
+  -> mark -web models as tool_calling:false
+  -> write config.providers.omni.models
+  -> refresh Pi model registry
+  -> re-register omni provider
+```
+
+## Data Flow: Native Tool Model
+
+```text
+Pi agent
+  -> streamOmni(model, context, options)
+  -> shouldUsePromptTools(model) === false
+  -> getApiProvider("openai-completions")
+  -> provider.streamSimple(model, context, options)
+  -> OmniRoute receives native tools
+  -> model returns native tool_calls
+  -> Pi executes tools
+```
+
+## Data Flow: Chat-Only / Prompt Tool Model
+
+```text
+Pi agent
+  -> streamOmni(model, context, options)
+  -> shouldUsePromptTools(model) === true
+  -> streamWithPromptTools(model, context, options)
+  -> renderToolProtocol(context.tools)
+  -> flattenMessages(context.messages)
+  -> call openai-completions with tools: []
+  -> parse <tool_call> blocks from full text response
+  -> emit Pi-native toolcall_* stream events
+  -> Pi executes tools
+```
+
+## Why `models.json` Is Re-read
+
+Pi parses configured models into runtime `Model` objects. Its schema keeps supported fields like:
+
+```text
+id, name, api, provider, baseUrl, reasoning, input, contextWindow, maxTokens, compat
+```
+
+Custom synced fields like this are not preserved:
+
+```json
+"tool_calling": false
+```
+
+So `modelConfigToolCallingFalse()` reads raw `models.json` to recover that field at request time.
+
+## Tool Mode Algorithm
+
+```ts
+promptTools =
+  modelConfigToolCallingFalse(model) ||
+  id/name contains "-web" ||
+  provider contains "-web"
+```
+
+If `promptTools` is false, native OpenAI-compatible tool calling is used.
+
+## Prompt Tool Design
+
+Prompt mode uses this text protocol:
+
+```xml
+<tool_call>
+{"name":"tool_name","arguments":{}}
+</tool_call>
+```
+
+Why XML-like tags:
+
+- easier to parse than arbitrary JSON in prose
+- allows normal answer text before tool call
+- supports multiple tool calls
+- can replay history using same structure
+
+## Stream Event Conversion
+
+`streamWithPromptTools()` builds an `AssistantMessage` manually and pushes event stream entries:
+
+```text
+start
+text_start/text_delta/text_end       if prose exists
+toolcall_start/toolcall_delta/toolcall_end for each parsed call
+done(reason: "toolUse" | "stop")
+```
+
+This makes Pi's normal agent loop execute tools, even though upstream model only wrote text.
+
+## Known Trade-offs
+
+- Prompt mode is buffered: it waits for full model output before parsing tool calls.
+- Images in history/tool results are dropped in prompt mode.
+- Small models may emit malformed JSON; parse errors are returned as visible assistant text so the model can self-correct next turn.
+- Prompt tool calls are only as reliable as model instruction following.
+
+## Extension Boundaries
+
+This repo does not implement OmniRoute itself. It only:
+
+- calls OmniRoute `/v1/models`
+- routes chat completions through Pi's built-in `openai-completions` provider
+- stores Pi config in `models.json`
+- registers Pi commands/provider

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,7 +47,7 @@ Saved provider shape:
   -> filter non-chat/image-only models
   -> normalize input modalities
   -> copy context/max token/reasoning metadata
-  -> mark -web models as tool_calling:false
+  -> mark models with -web in id/name/provider/owned_by as tool_calling:false
   -> write config.providers.omni.models
   -> refresh Pi model registry
   -> re-register omni provider
@@ -102,8 +102,8 @@ So `modelConfigToolCallingFalse()` reads raw `models.json` to recover that field
 ```ts
 promptTools =
   modelConfigToolCallingFalse(model) ||
-  id/name contains "-web" ||
-  provider contains "-web"
+  id/name/provider contains "-web" ||
+  synced raw owned_by/provider marker contained "-web"
 ```
 
 If `promptTools` is false, native OpenAI-compatible tool calling is used.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -145,6 +145,10 @@ This makes Pi's normal agent loop execute tools, even though upstream model only
 - Small models may emit malformed JSON; parse errors are returned as visible assistant text so the model can self-correct next turn.
 - Prompt tool calls are only as reliable as model instruction following.
 
+## API Key Handling
+
+`/omni setup` lets the API key be blank for local/public OmniRoute deployments. Pi's provider registry and OpenAI-compatible SDK path still require a non-empty API key string when registering custom models, so provider registration uses a harmless dummy value (`omniroute-public`) only when the saved key is empty. Real OmniRoute requests use the saved key when present.
+
 ## Extension Boundaries
 
 This repo does not implement OmniRoute itself. It only:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ For model sync changes:
 
 - `/omni setup` saves URL/API key.
 - `/omni sync` writes models to `~/.pi/agent/models.json`.
-- Web-synced models get `tool_calling:false`.
+- Web-synced models get `tool_calling:false` even when `-web` only appears in OmniRoute `owned_by`/provider metadata.
 - Normal models do not get forced into prompt mode.
 
 For prompt tool changes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing
+
+## Quick Start
+
+```bash
+npm install
+npm run typecheck
+npm run smoke
+```
+
+## Development Scripts
+
+| Command | Purpose |
+|---|---|
+| `npm run typecheck` | Type-check `index.ts` with NodeNext settings. |
+| `npm run smoke` | Import the extension module and verify it loads. |
+
+## Local Pi Testing
+
+From this repo:
+
+```bash
+pi -e ./index.ts
+```
+
+Or install normally:
+
+```bash
+pi install git:github.com/md-riaz/omniroute-pi-ext-integration
+```
+
+Then in Pi:
+
+```text
+/omni setup
+/omni sync
+/model cgpt-web/gpt-5.4-pro
+```
+
+## Before Opening a PR
+
+Run:
+
+```bash
+npm run typecheck
+npm run smoke
+```
+
+Check working tree:
+
+```bash
+git status --short
+git diff --stat
+```
+
+## Documentation Rules
+
+If changing user-visible behavior, update `README.md`.
+
+If changing architecture or core data flow, update `ARCHITECTURE.md`.
+
+If changing function names or scan paths, update `AI.md` so future AI agents do not waste tokens rediscovering the repo.
+
+## Coding Rules
+
+- Keep extension in `index.ts` unless feature grows enough to justify splitting files.
+- Add short comments for non-obvious functions.
+- Preserve `/model` UX; do not add duplicate providers for prompt tools.
+- Keep `omni` as provider name.
+- Keep prompt fallback automatic.
+- Avoid destructive behavior in `/omni sync`; it should only replace `config.providers.omni.models`.
+
+## Testing Checklist
+
+For model sync changes:
+
+- `/omni setup` saves URL/API key.
+- `/omni sync` writes models to `~/.pi/agent/models.json`.
+- Web-synced models get `tool_calling:false`.
+- Normal models do not get forced into prompt mode.
+
+For prompt tool changes:
+
+- `npm run typecheck` passes.
+- `npm run smoke` passes.
+- A `tool_calling:false` model can trigger a tool call.
+- A native model still uses native tool calls.
+- Bad `<tool_call>` JSON surfaces correction text instead of silent failure.
+
+## Commit Style
+
+Use descriptive commit messages. Good examples:
+
+```text
+Add prompt-tool fallback for web-synced OmniRoute models
+Document OmniRoute prompt tool architecture
+Preserve raw tool_calling metadata during model sync
+```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Connect to your local or remote OmniRoute server, browse models, manage combos, 
 - 🔮 **Wizard-Based Setup**: Just run `/omni setup` inside Pi. No manual JSON editing needed.
 - ⚡ **Pure HTTP Client**: Works securely and seamlessly whether your OmniRoute server is running locally on `localhost:20128` or hosted on a remote VPS.
 - 🔄 **Combo & Model Sync**: Instantly push all OmniRoute combos and available models into Pi’s `Ctrl+P` model picker with full metadata (context windows, max tokens, reasoning support, and vision capabilities).
+- 🛠️ **Prompt Tool Fallback for Chat-Only Models**: Models that do not support native `tool_calls` can still use Pi tools through prompt-emulated tool calling.
+- 🔁 **Same `/model` Workflow**: Switch models normally; the extension chooses native tools or prompt tools automatically.
 - 📊 **Real-time Routing Feedback**: Status bar dynamically shows which model *actually* served each response (via call logs).
 - 🧬 **Smart Sorting**: Syncing organizes your model list by provider/group (`owned_by`) for a cleaner `Ctrl+P` experience.
 - 🛠️ **Diagnostics & Health**: Spot expired tokens, connection failures, or disconnected providers right when Pi starts (management endpoints must be accessible).
@@ -32,13 +34,143 @@ pi install git:github.com/md-riaz/omniroute-pi-ext-integration
    ```
 3. **Enter Credentials:** Enter your OmniRoute Server URL and your API Key when prompted.
 4. **Sync Models:** Run `/omni sync` to populate the `Ctrl+P` list with all your provider models and combos.
+5. **Switch Models Normally:** Use `/model` as usual. No separate prompt-tools provider is needed.
+
+## Prompt Tool Fallback
+
+Some OmniRoute-synced models are chat-only: they can answer text, but they do not return native OpenAI-style `message.tool_calls`. This is common for web-synced model IDs such as:
+
+```text
+cgpt-web/gpt-5.4-pro
+chatgpt-web/gpt-5.5
+bb-web/gpt-4-turbo
+ds-web/deepseek-v4-pro
+```
+
+For these models, the extension keeps the same `omni` provider and `/model` workflow, but internally switches to prompt-emulated tool calling.
+
+### Native tool mode
+
+Used for normal tool-capable models.
+
+```text
+Pi agent
+  -> omni provider
+  -> OmniRoute with native tools: [...]
+  -> model returns native tool_calls
+  -> Pi executes tools
+```
+
+### Prompt tool mode
+
+Used when a model is chat-only or marked as not supporting native tool calls.
+
+```text
+Pi agent
+  -> omni provider
+  -> extension renders Pi tools as text instructions
+  -> OmniRoute request is sent with tools: []
+  -> model writes <tool_call>{...}</tool_call>
+  -> extension converts that text back into Pi native toolCall events
+  -> Pi executes tools normally
+```
+
+The model is taught this wire format:
+
+```xml
+<tool_call>
+{"name":"read","arguments":{"path":"index.ts"}}
+</tool_call>
+```
+
+Tool results are fed back in history as text:
+
+```xml
+<tool_result tool="read" id="call_123">
+...tool output...
+</tool_result>
+```
+
+## How Prompt Tool Mode Is Detected
+
+Prompt tool mode is enabled when either condition is true:
+
+1. The model ID/name/provider contains `-web`.
+2. The synced `models.json` model entry contains:
+
+```json
+{
+  "tool_calling": false
+}
+```
+
+The second check reads raw `models.json` because Pi's runtime `Model` object does not preserve custom fields like `tool_calling`.
+
+Example synced model entry:
+
+```json
+{
+  "id": "cgpt-web/gpt-5.4-pro",
+  "name": "Gpt 5.4 Pro",
+  "api": "omni-prompt-tools",
+  "tool_calling": false,
+  "input": ["text", "image"],
+  "contextWindow": 400000,
+  "maxTokens": 65535,
+  "reasoning": true
+}
+```
+
+## Model Switching
+
+Use Pi's normal model picker/command:
+
+```text
+/model cgpt-web/gpt-5.4-pro
+/model codex/gpt-5.2
+/model premium
+```
+
+The extension routes automatically:
+
+| Model kind | Detection | Tool mode |
+|---|---|---|
+| Web-synced model | ID/name/provider contains `-web` | Prompt-emulated tools |
+| Explicit chat-only model | `tool_calling: false` in `models.json` | Prompt-emulated tools |
+| Normal model | No fallback marker | Native tools |
 
 ## Commands Reference
 
+| Command | Description |
+|---|---|
 | `/omni` | Dashboard showing server health, active connections, and combos |
 | `/omni sync` | Sync your Pi model picker with all healthy OmniRoute instances |
 | `/omni setup` | Launch interactive wizard to link Pi with your OmniRoute gateway |
 | `/omni dashboard` | Get the direct link to your OmniRoute web interface |
+
+## Development
+
+This repo is intentionally small and AI-friendly:
+
+| File | Purpose |
+|---|---|
+| `AGENTS.md` | Required instructions for AI agents editing this repo. |
+| `AI.md` | Fast handoff guide for AI agents and future maintainers. |
+| `ARCHITECTURE.md` | Data flows and prompt-tool architecture. |
+| `CONTRIBUTING.md` | Local setup, test checklist, and contribution rules. |
+| `index.ts` | Extension implementation. |
+
+Run TypeScript check:
+
+```bash
+npm run typecheck
+```
+
+Smoke-test extension import:
+
+```bash
+npm run smoke
+```
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bb-web/gpt-4-turbo
 ds-web/deepseek-v4-pro
 ```
 
-For these models, the extension keeps the same `omni` provider and `/model` workflow, but internally switches to prompt-emulated tool calling.
+For these models, the extension keeps the same Pi provider (`omni`) and `/model` workflow, but internally switches to prompt-emulated tool calling.
 
 ### Native tool mode
 
@@ -64,6 +64,8 @@ Pi agent
 ### Prompt tool mode
 
 Used when a model is chat-only or marked as not supporting native tool calls.
+
+Prompt tool mode is intentionally buffered: the extension waits for the full model response before showing text, because it must parse complete `<tool_call>` blocks before emitting Pi-native tool events.
 
 ```text
 Pi agent
@@ -95,7 +97,7 @@ Tool results are fed back in history as text:
 
 Prompt tool mode is enabled when either condition is true:
 
-1. The model ID/name/provider/OmniRoute `owned_by` marker contains `-web` during sync.
+1. The upstream model metadata contains `-web` during sync, such as OmniRoute model ID/name, `owned_by`, or model provider label. This does not change the Pi provider ID, which remains `omni`.
 2. The synced `models.json` model entry contains:
 
 ```json
@@ -135,7 +137,7 @@ The extension routes automatically:
 
 | Model kind | Detection | Tool mode |
 |---|---|---|
-| Web-synced model | ID/name/provider or OmniRoute `owned_by` contains `-web` | Prompt-emulated tools |
+| Web-synced model | Upstream model ID/name, OmniRoute `owned_by`, or model provider label contains `-web` | Prompt-emulated tools |
 | Explicit chat-only model | `tool_calling: false` in `models.json` | Prompt-emulated tools |
 | Normal model | No fallback marker | Native tools |
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Tool results are fed back in history as text:
 
 Prompt tool mode is enabled when either condition is true:
 
-1. The model ID/name/provider contains `-web`.
+1. The model ID/name/provider/OmniRoute `owned_by` marker contains `-web` during sync.
 2. The synced `models.json` model entry contains:
 
 ```json
@@ -135,7 +135,7 @@ The extension routes automatically:
 
 | Model kind | Detection | Tool mode |
 |---|---|---|
-| Web-synced model | ID/name/provider contains `-web` | Prompt-emulated tools |
+| Web-synced model | ID/name/provider or OmniRoute `owned_by` contains `-web` | Prompt-emulated tools |
 | Explicit chat-only model | `tool_calling: false` in `models.json` | Prompt-emulated tools |
 | Normal model | No fallback marker | Native tools |
 

--- a/index.ts
+++ b/index.ts
@@ -261,8 +261,10 @@ function renderToolCallBlock(tc: ToolCall): string {
 	return `<tool_call>\n${JSON.stringify({ name: tc.name, arguments: tc.arguments })}\n</tool_call>`;
 }
 
+type FlattenableMessage = Message | { role: "system"; content: string | TextContent[]; timestamp?: number };
+
 /** Flatten native Pi message history into user/assistant text history for non-tool-capable chat APIs. */
-function flattenMessages(messages: Message[]): Message[] {
+function flattenMessages(messages: FlattenableMessage[]): Message[] {
 	const out: Message[] = [];
 	const pushText = (role: "user" | "assistant", text: string) => {
 		if (!text.trim()) return;
@@ -280,13 +282,18 @@ function flattenMessages(messages: Message[]): Message[] {
 			pushText("user", textOf(msg.content));
 		} else if (msg.role === "assistant") {
 			const prose = textOf(msg.content);
-			const calls = msg.content.filter((c): c is ToolCall => c.type === "toolCall");
+			const calls = Array.isArray(msg.content)
+				? msg.content.filter((c): c is ToolCall => c.type === "toolCall")
+				: [];
 			const parts = [prose, ...calls.map(renderToolCallBlock)].filter((s) => s.trim());
 			pushText("assistant", parts.join("\n\n"));
 		} else if (msg.role === "toolResult") {
 			const body = textOf(msg.content);
 			const tag = msg.isError ? "tool_result error" : "tool_result";
 			pushText("user", `<${tag} tool="${msg.toolName}" id="${msg.toolCallId}">\n${body}\n</tool_result>`);
+		} else if (msg.role === "system") {
+			// Pi normally uses context.systemPrompt, but preserve unexpected system messages defensively.
+			pushText("user", `<system>\n${textOf(msg.content)}\n</system>`);
 		}
 	}
 	return out;

--- a/index.ts
+++ b/index.ts
@@ -397,6 +397,7 @@ function streamWithPromptTools(
 
 			const innerModel: Model<any> = { ...model, api: UNDERLYING_API };
 			const inner = provider.streamSimple(innerModel, innerContext, options);
+			// Prompt-tool mode is intentionally buffered: complete text is needed to parse <tool_call> blocks safely.
 			const innerResult = await inner.result();
 
 			output.usage = { ...innerResult.usage };

--- a/index.ts
+++ b/index.ts
@@ -13,19 +13,39 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	calculateCost,
+	createAssistantMessageEventStream,
+	getApiProvider,
+	type AssistantMessage,
+	type AssistantMessageEventStream,
+	type Context,
+	type Message,
+	type Model,
+	type SimpleStreamOptions,
+	type TextContent,
+	type Tool,
+	type ToolCall,
+} from "@earendil-works/pi-ai";
 import { homedir } from "os";
 
+const OMNI_PROMPT_TOOLS_API = "omni-prompt-tools";
+const UNDERLYING_API = "openai-completions";
+
+/** Resolve Pi's models.json path; PI_HOME lets tests/custom installs point elsewhere. */
 function modelsJsonPath(): string {
 	return process.env.PI_HOME
 		? `${process.env.PI_HOME}/models.json`
 		: `${homedir()}/.pi/agent/models.json`;
 }
 
+/** Read raw models.json because custom metadata like tool_calling is not preserved by Pi's Model type. */
 function readModelsJson(): any {
 	const fs = require("fs");
 	return JSON.parse(fs.readFileSync(modelsJsonPath(), "utf8"));
 }
 
+/** Load OmniRoute base URL from models.json, falling back to local default before setup. */
 function getOmniUrl(): string {
 	try {
 		const url = readModelsJson()?.providers?.omni?.baseUrl;
@@ -34,6 +54,7 @@ function getOmniUrl(): string {
 	return "http://127.0.0.1:20128";
 }
 
+/** Load OmniRoute API key from models.json for direct extension HTTP calls. */
 function getApiKey(): string {
 	try {
 		return readModelsJson()?.providers?.omni?.apiKey || "";
@@ -42,6 +63,7 @@ function getApiKey(): string {
 	}
 }
 
+/** Check whether /omni setup has created a provider entry. */
 function isOmniConfigured(): boolean {
 	try {
 		return !!readModelsJson()?.providers?.omni;
@@ -53,6 +75,39 @@ function isOmniConfigured(): boolean {
 let OMNI_URL = getOmniUrl();
 let DASHBOARD_URL = OMNI_URL;
 
+/**
+ * Register/refresh the omni provider with a custom stream handler.
+ * This keeps /model UX unchanged while letting us choose native vs prompt tools at runtime.
+ */
+function registerOmniProvider(pi: ExtensionAPI): void {
+	try {
+		const provider = readModelsJson()?.providers?.omni;
+		if (!provider) return;
+
+		pi.registerProvider("omni", {
+			name: "OmniRoute",
+			baseUrl: (provider.baseUrl || OMNI_URL).replace(/\/$/, ""),
+			apiKey: provider.apiKey || " ",
+			api: OMNI_PROMPT_TOOLS_API,
+			streamSimple: streamOmni,
+			models: (provider.models || []).map((model: any) => ({
+				id: model.id,
+				name: model.name || humanName(model.id),
+				api: OMNI_PROMPT_TOOLS_API,
+				reasoning: model.reasoning ?? false,
+				thinkingLevelMap: model.thinkingLevelMap,
+				input: model.input || ["text"],
+				cost: model.cost || { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: model.contextWindow || 128000,
+				maxTokens: model.maxTokens || 16384,
+				headers: model.headers,
+				compat: model.compat,
+			})),
+		});
+	} catch {}
+}
+
+/** Call OmniRoute management/public API using saved URL/key. */
 async function api(path: string, opts?: RequestInit): Promise<any> {
 	const apiKey = getApiKey();
 	const res = await fetch(`${OMNI_URL}${path}`, {
@@ -74,6 +129,7 @@ async function api(path: string, opts?: RequestInit): Promise<any> {
 	return text ? JSON.parse(text) : {};
 }
 
+/** Quick health probe used for status bar and /omni status. */
 async function checkOmniRouteHealth(): Promise<boolean> {
 	try {
 		const res = await fetch(`${OMNI_URL}/v1/models`, { signal: AbortSignal.timeout(3000) });
@@ -95,6 +151,7 @@ type SyncedModel = {
 	tool_calling?: boolean;
 };
 
+/** Normalize OmniRoute modality names to Pi-supported input values. */
 function normalizeModalities(value: unknown): string[] {
 	if (!Array.isArray(value)) return [];
 	const out: string[] = [];
@@ -108,6 +165,7 @@ function normalizeModalities(value: unknown): string[] {
 	return out;
 }
 
+/** Filter out image-generation/non-chat models so Ctrl+P only shows usable chat models. */
 function isPiChatModel(model: any): boolean {
 	if (!model || typeof model !== "object") return true;
 	const output = normalizeModalities(model.output_modalities ?? model.output);
@@ -115,10 +173,293 @@ function isPiChatModel(model: any): boolean {
 	return output.length === 0 || output.includes("text");
 }
 
+/** Detect web-synced models whose native function calling is unreliable/missing. */
 function isWebSyncedModel(id: string, name?: string): boolean {
 	return `${id} ${name || ""}`.toLowerCase().includes("-web");
 }
 
+/** Read per-model tool_calling:false from models.json; Pi strips this custom field from runtime Model. */
+function modelConfigToolCallingFalse(model: Pick<Model<any>, "id" | "provider">): boolean {
+	try {
+		const provider = readModelsJson()?.providers?.[model.provider];
+		const configured = (provider?.models || []).find((m: any) => m?.id === model.id);
+		return configured?.tool_calling === false;
+	} catch {
+		return false;
+	}
+}
+
+/** Decide whether a model needs prompt-emulated tools instead of native OpenAI tool_calls. */
+function shouldUsePromptTools(model: Pick<Model<any>, "id" | "name" | "provider">): boolean {
+	return (
+		modelConfigToolCallingFalse(model) ||
+		isWebSyncedModel(model.id, model.name) ||
+		`${model.provider || ""}`.toLowerCase().includes("-web")
+	);
+}
+
+let protocolCache: { key: string; text: string } | undefined;
+
+/** Stable cache key for the active tool set; avoids rebuilding identical prompt protocol each turn. */
+function toolsSignature(tools: Tool[]): string {
+	return JSON.stringify(tools.map((t) => [t.name, t.description, t.parameters]));
+}
+
+/** Render Pi's structured tools as text instructions for chat-only models. */
+function renderToolProtocol(tools: Tool[]): string {
+	const key = toolsSignature(tools);
+	if (protocolCache && protocolCache.key === key) return protocolCache.text;
+
+	const lines: string[] = [
+		"# Tool calling protocol",
+		"",
+		"You can use tools. To call one or more tools, write any reasoning first, then end your",
+		"message with one or more tool-call blocks in EXACTLY this format:",
+		"",
+		"<tool_call>",
+		'{"name": "<tool_name>", "arguments": { ... }}',
+		"</tool_call>",
+		"",
+		"Rules:",
+		"- The JSON must be valid and `arguments` must match the tool's parameter schema.",
+		"- Put the JSON directly inside the tags. Do NOT wrap it in ```json markdown fences.",
+		'- `arguments` must be a JSON object literal, not a string (use {"path":"x"}, not "{\\"path\\":\\"x\\"}").',
+		"- Emit multiple <tool_call> blocks to call several tools in one turn.",
+		"- After emitting tool calls, STOP and wait; tool results arrive as <tool_result> messages.",
+		"- If no tool is needed, answer normally with NO <tool_call> block.",
+		"",
+		"## Available tools",
+		"",
+	];
+
+	for (const tool of tools) {
+		lines.push(`### ${tool.name}`);
+		lines.push(tool.description);
+		lines.push("Parameters (JSON Schema):");
+		lines.push("```json");
+		lines.push(JSON.stringify(tool.parameters, null, 2));
+		lines.push("```");
+		lines.push("");
+	}
+
+	const text = lines.join("\n");
+	protocolCache = { key, text };
+	return text;
+}
+
+/** Extract text blocks and drop unsupported content like images for plain chat endpoints. */
+function textOf(content: string | (TextContent | { type: string })[]): string {
+	if (typeof content === "string") return content;
+	return content
+		.filter((c): c is TextContent => c.type === "text")
+		.map((c) => c.text)
+		.join("");
+}
+
+/** Convert prior native Pi tool calls into text blocks chat-only models can read. */
+function renderToolCallBlock(tc: ToolCall): string {
+	return `<tool_call>\n${JSON.stringify({ name: tc.name, arguments: tc.arguments })}\n</tool_call>`;
+}
+
+/** Flatten native Pi message history into user/assistant text history for non-tool-capable chat APIs. */
+function flattenMessages(messages: Message[]): Message[] {
+	const out: Message[] = [];
+	const pushText = (role: "user" | "assistant", text: string) => {
+		if (!text.trim()) return;
+		const last = out[out.length - 1];
+		if (last && last.role === role) {
+			const block = (last.content as TextContent[])[0];
+			block.text += `\n\n${text}`;
+			return;
+		}
+		out.push({ role, content: [{ type: "text", text }], timestamp: Date.now() } as Message);
+	};
+
+	for (const msg of messages) {
+		if (msg.role === "user") {
+			pushText("user", textOf(msg.content));
+		} else if (msg.role === "assistant") {
+			const prose = textOf(msg.content);
+			const calls = msg.content.filter((c): c is ToolCall => c.type === "toolCall");
+			const parts = [prose, ...calls.map(renderToolCallBlock)].filter((s) => s.trim());
+			pushText("assistant", parts.join("\n\n"));
+		} else if (msg.role === "toolResult") {
+			const body = textOf(msg.content);
+			const tag = msg.isError ? "tool_result error" : "tool_result";
+			pushText("user", `<${tag} tool="${msg.toolName}" id="${msg.toolCallId}">\n${body}\n</tool_result>`);
+		}
+	}
+	return out;
+}
+
+const TOOL_CALL_RE = /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>/g;
+
+/** Tolerate models that wrap tool JSON inside ```json fences despite instructions. */
+function stripCodeFence(raw: string): string {
+	return raw
+		.replace(/^\s*```(?:json|JSON)?\s*\n?/, "")
+		.replace(/\n?\s*```\s*$/, "")
+		.trim();
+}
+
+/** Tolerate models that emit arguments as a JSON string instead of an object. */
+function coerceArguments(value: unknown): Record<string, any> {
+	if (value && typeof value === "object") return value as Record<string, any>;
+	if (typeof value === "string") {
+		try {
+			const parsed = JSON.parse(value);
+			if (parsed && typeof parsed === "object") return parsed as Record<string, any>;
+		} catch {}
+	}
+	return {};
+}
+
+/** Parse <tool_call> blocks from model text and preserve parse errors as model-visible feedback. */
+function parseToolCalls(text: string): {
+	prose: string;
+	calls: { name: string; arguments: Record<string, any> }[];
+	errors: string[];
+} {
+	const calls: { name: string; arguments: Record<string, any> }[] = [];
+	const errors: string[] = [];
+	let match: RegExpExecArray | null;
+	TOOL_CALL_RE.lastIndex = 0;
+	while ((match = TOOL_CALL_RE.exec(text)) !== null) {
+		const body = stripCodeFence(match[1]);
+		try {
+			const parsed = JSON.parse(body);
+			if (parsed && typeof parsed.name === "string") {
+				calls.push({ name: parsed.name, arguments: coerceArguments(parsed.arguments) });
+			} else {
+				errors.push(`tool_call missing a string "name": ${body.slice(0, 200)}`);
+			}
+		} catch (e) {
+			errors.push(`invalid JSON in <tool_call> (${e instanceof Error ? e.message : "parse error"}): ${body.slice(0, 200)}`);
+		}
+	}
+	return { prose: text.replace(TOOL_CALL_RE, "").trim(), calls, errors };
+}
+
+/**
+ * Prompt-tool stream path for chat-only models.
+ * It injects tool schemas as text, calls OmniRoute without native tools, then converts parsed blocks back to Pi toolCall events.
+ */
+function streamWithPromptTools(
+	model: Model<any>,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+	const stream = createAssistantMessageEventStream();
+
+	(async () => {
+		const output: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+
+		try {
+			stream.push({ type: "start", partial: output });
+
+			const tools = context.tools ?? [];
+			const innerContext: Context = {
+				systemPrompt: tools.length > 0
+					? `${context.systemPrompt ?? ""}\n\n${renderToolProtocol(tools)}`.trim()
+					: context.systemPrompt,
+				messages: flattenMessages(context.messages),
+				tools: [],
+			};
+
+			const provider = getApiProvider(UNDERLYING_API);
+			if (!provider) throw new Error(`Underlying api "${UNDERLYING_API}" is not registered`);
+
+			const innerModel: Model<any> = { ...model, api: UNDERLYING_API };
+			const inner = provider.streamSimple(innerModel, innerContext, options);
+			const innerResult = await inner.result();
+
+			output.usage = { ...innerResult.usage };
+			output.responseId = innerResult.responseId;
+			output.responseModel = innerResult.responseModel;
+			if (innerResult.stopReason === "error" || innerResult.stopReason === "aborted") {
+				output.stopReason = innerResult.stopReason;
+				output.errorMessage = innerResult.errorMessage;
+				stream.push({ type: "error", reason: output.stopReason, error: output });
+				stream.end();
+				return;
+			}
+
+			const rawText = textOf(innerResult.content as TextContent[]);
+			const parsed = tools.length > 0 ? parseToolCalls(rawText) : { prose: rawText, calls: [], errors: [] as string[] };
+			let prose = parsed.prose;
+
+			if (parsed.errors.length > 0) {
+				const note = [
+					"[omni-prompt-tools] Could not parse tool call(s). Re-emit each as:",
+					'<tool_call>{"name":"tool_name","arguments":{}}</tool_call>',
+					...parsed.errors.map((e) => `- ${e}`),
+				].join("\n");
+				prose = prose ? `${prose}\n\n${note}` : note;
+			}
+
+			if (prose) {
+				output.content.push({ type: "text", text: prose });
+				const idx = output.content.length - 1;
+				stream.push({ type: "text_start", contentIndex: idx, partial: output });
+				stream.push({ type: "text_delta", contentIndex: idx, delta: prose, partial: output });
+				stream.push({ type: "text_end", contentIndex: idx, content: prose, partial: output });
+			}
+
+			parsed.calls.forEach((call, i) => {
+				const id = `call_${Date.now().toString(36)}_${i}_${Math.random().toString(36).slice(2, 8)}`;
+				const toolCall: ToolCall = { type: "toolCall", id, name: call.name, arguments: call.arguments };
+				output.content.push(toolCall);
+				const idx = output.content.length - 1;
+				stream.push({ type: "toolcall_start", contentIndex: idx, partial: output });
+				stream.push({ type: "toolcall_delta", contentIndex: idx, delta: JSON.stringify(call.arguments), partial: output });
+				stream.push({ type: "toolcall_end", contentIndex: idx, toolCall, partial: output });
+			});
+
+			output.stopReason = parsed.calls.length > 0 ? "toolUse" : "stop";
+			calculateCost(model, output.usage);
+			stream.push({ type: "done", reason: output.stopReason as "stop" | "length" | "toolUse", message: output });
+			stream.end();
+		} catch (error) {
+			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+			output.errorMessage = error instanceof Error ? error.message : String(error);
+			stream.push({ type: "error", reason: output.stopReason, error: output });
+			stream.end();
+		}
+	})();
+
+	return stream;
+}
+
+/** Main provider stream router: web/tool_calling:false models use prompt tools; all others use native tools. */
+function streamOmni(
+	model: Model<any>,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+	if (shouldUsePromptTools(model)) return streamWithPromptTools(model, context, options);
+
+	const provider = getApiProvider(UNDERLYING_API);
+	if (!provider) throw new Error(`Underlying api "${UNDERLYING_API}" is not registered`);
+	return provider.streamSimple({ ...model, api: UNDERLYING_API }, context, options);
+}
+
+/** Merge duplicate OmniRoute model IDs while preserving best metadata from each source row. */
 function upsertSyncedModel(models: SyncedModel[], next: SyncedModel): void {
 	const index = models.findIndex((model) => model.id === next.id);
 	if (index < 0) {
@@ -138,6 +479,7 @@ function upsertSyncedModel(models: SyncedModel[], next: SyncedModel): void {
 	};
 }
 
+/** Fetch OmniRoute /v1/models and convert rows into Pi models.json entries. */
 async function getAllModelsFromOmniRoute(): Promise<SyncedModel[]> {
 	const results: SyncedModel[] = [];
 	const data = await api("/v1/models");
@@ -151,7 +493,7 @@ async function getAllModelsFromOmniRoute(): Promise<SyncedModel[]> {
 			id,
 			name: humanName(id),
 			owned_by: m.owned_by,
-			api: "openai-completions",
+			api: OMNI_PROMPT_TOOLS_API,
 		};
 
 		if (isWebSyncedModel(id, m.name)) synced.tool_calling = false;
@@ -180,6 +522,7 @@ async function getAllModelsFromOmniRoute(): Promise<SyncedModel[]> {
 		.map(({ owned_by, ...rest }) => rest);
 }
 
+/** Convert provider/model-id strings into friendlier Ctrl+P labels. */
 function humanName(id: string): string {
 	const parts = id.split("/");
 	const provider = parts.length > 1 ? parts[0] : "";
@@ -200,6 +543,7 @@ function humanName(id: string): string {
 
 export default function (pi: ExtensionAPI) {
 	let healthInterval: ReturnType<typeof setInterval> | undefined;
+	registerOmniProvider(pi);
 
 	pi.on("model_select", async (event: any, ctx: any) => {
 		try {
@@ -288,6 +632,7 @@ export default function (pi: ExtensionAPI) {
 					fs.writeFileSync(path, JSON.stringify(config, null, 2));
 
 					ctx.modelRegistry.refresh();
+					registerOmniProvider(pi);
 
 					ctx.ui.notify(
 						`✅ Synced ${allModels.length} models to Ctrl+P (was ${oldCount})`,
@@ -336,7 +681,7 @@ export default function (pi: ExtensionAPI) {
 					if (!config.providers) config.providers = {};
 					config.providers.omni = {
 						baseUrl,
-						api: "openai-completions",
+						api: OMNI_PROMPT_TOOLS_API,
 						apiKey: apiKey.trim(),
 						models: [],
 					};
@@ -345,6 +690,7 @@ export default function (pi: ExtensionAPI) {
 
 					OMNI_URL = baseUrl;
 					DASHBOARD_URL = baseUrl;
+					registerOmniProvider(pi);
 
 					ctx.ui.notify(
 						"✅ OmniRoute setup complete and saved to models.json\n\n" +

--- a/index.ts
+++ b/index.ts
@@ -174,8 +174,10 @@ function isPiChatModel(model: any): boolean {
 }
 
 /** Detect web-synced models whose native function calling is unreliable/missing. */
-function isWebSyncedModel(id: string, name?: string): boolean {
-	return `${id} ${name || ""}`.toLowerCase().includes("-web");
+function isWebSyncedModel(...markers: unknown[]): boolean {
+	return markers
+		.filter((marker): marker is string => typeof marker === "string")
+		.some((marker) => marker.toLowerCase().includes("-web"));
 }
 
 /** Read per-model tool_calling:false from models.json; Pi strips this custom field from runtime Model. */
@@ -183,7 +185,7 @@ function modelConfigToolCallingFalse(model: Pick<Model<any>, "id" | "provider">)
 	try {
 		const provider = readModelsJson()?.providers?.[model.provider];
 		const configured = (provider?.models || []).find((m: any) => m?.id === model.id);
-		return configured?.tool_calling === false;
+		return configured?.tool_calling === false || isWebSyncedModel(configured?.id, configured?.name, configured?.owned_by, configured?.provider);
 	} catch {
 		return false;
 	}
@@ -193,7 +195,7 @@ function modelConfigToolCallingFalse(model: Pick<Model<any>, "id" | "provider">)
 function shouldUsePromptTools(model: Pick<Model<any>, "id" | "name" | "provider">): boolean {
 	return (
 		modelConfigToolCallingFalse(model) ||
-		isWebSyncedModel(model.id, model.name) ||
+		isWebSyncedModel(model.id, model.name, model.provider) ||
 		`${model.provider || ""}`.toLowerCase().includes("-web")
 	);
 }
@@ -503,7 +505,7 @@ async function getAllModelsFromOmniRoute(): Promise<SyncedModel[]> {
 			api: OMNI_PROMPT_TOOLS_API,
 		};
 
-		if (isWebSyncedModel(id, m.name)) synced.tool_calling = false;
+		if (isWebSyncedModel(id, m.name, m.owned_by, m.provider)) synced.tool_calling = false;
 
 		const input = normalizeModalities(m.input_modalities ?? m.input);
 		synced.input = input.length > 0 ? input : ["text"];

--- a/index.ts
+++ b/index.ts
@@ -87,7 +87,8 @@ function registerOmniProvider(pi: ExtensionAPI): void {
 		pi.registerProvider("omni", {
 			name: "OmniRoute",
 			baseUrl: (provider.baseUrl || OMNI_URL).replace(/\/$/, ""),
-			apiKey: provider.apiKey || " ",
+			// Pi/OpenAI SDK require a non-empty apiKey; OmniRoute may ignore this dummy for public/local setups.
+			apiKey: provider.apiKey || "omniroute-public",
 			api: OMNI_PROMPT_TOOLS_API,
 			streamSimple: streamOmni,
 			models: (provider.models || []).map((model: any) => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "omniroute-pi-ext-integration",
       "version": "1.0.1",
       "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.9.1",
+        "typescript": "^6.0.3"
+      },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.60.0"
       }
@@ -1823,13 +1827,12 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/retry": {
@@ -3379,6 +3382,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
@@ -3403,11 +3420,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
-      "license": "MIT",
-      "peer": true
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
       "./index.ts"
     ]
   },
+  "scripts": {
+    "typecheck": "tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --types node index.ts",
+    "smoke": "node -e \"import('./index.ts').then(()=>console.log('import ok')).catch(e=>{console.error(e);process.exit(1)})\""
+  },
   "author": "md-riaz",
   "license": "MIT",
   "repository": {
@@ -34,5 +38,9 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.60.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --types node index.ts",
-    "smoke": "node -e \"import('./index.ts').then(()=>console.log('import ok')).catch(e=>{console.error(e);process.exit(1)})\""
+    "smoke": "node --experimental-strip-types -e \"import(\\\"./index.ts\\\").then(()=>console.log(\\\"import ok\\\")).catch(e=>{console.error(e);process.exit(1)})\""
   },
   "author": "md-riaz",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Add smart OmniRoute provider routing that keeps /model UX unchanged
- Route web-synced or tool_calling:false models through prompt-emulated tool calls
- Preserve native OpenAI-compatible tool calls for normal models
- Add AI-friendly docs: AGENTS.md, AI.md, ARCHITECTURE.md, CONTRIBUTING.md
- Add npm typecheck and smoke scripts

## Validation
- npm run typecheck
- npm run smoke


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added prompt-tool fallback feature enabling chat-only models to handle tool requests through automatic text-based emulation.
  * Automatic model-to-tool-mode detection optimizes tool handling for each model.
  * New `/omni dashboard` command.

* **Documentation**
  * Added comprehensive guides for contributors, architecture documentation, and development setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->