### PR TITLE
fix(prompt-tools): refresh protocol periodically for chat-only models

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -64,7 +64,7 @@ Real HTTP calls still use Pi's built-in OpenAI-compatible provider:
 const UNDERLYING_API = "openai-completions";
 ```
 
-Native mode passes tools normally. Prompt mode strips native tools and renders tool schemas as text.
+Native mode passes tools normally. Prompt mode strips native tools and injects a text prompt-tool protocol into the outbound system prompt. The first prompt-tool turn sends the full compact protocol; later turns send compact reminders until periodic or forced refresh.
 
 ## Tool Mode Decision
 
@@ -98,11 +98,13 @@ Read in this order:
 2. `streamOmni()` — runtime router for native vs prompt tool mode.
 3. `shouldUsePromptTools()` — decides if prompt tool fallback is needed.
 4. `streamWithPromptTools()` — prompt-tool stream implementation.
-5. `renderToolProtocol()` — converts Pi tool schemas into prompt text.
-6. `flattenMessages()` — converts native tool history into text history for chat-only models.
-7. `parseToolCalls()` — parses `<tool_call>` blocks from model output.
-8. `getAllModelsFromOmniRoute()` — fetches `/v1/models` and converts to Pi model entries.
-9. `humanName()` — user-friendly labels for Ctrl+P.
+5. `selectPromptToolProtocol()` — chooses full protocol vs compact reminder using session/model/tool state.
+6. `renderFullToolProtocol()` — converts all active Pi tools into compact prompt text with descriptions and parameter schemas.
+7. `renderToolProtocolReminder()` — sends cheap steady-state reminders with compact per-tool argument hints.
+8. `flattenMessages()` — converts native tool history into text history for chat-only models.
+9. `parseToolCalls()` — parses standalone `<tool_call>` blocks from model output and flags mixed prose/tool-call confusion.
+10. `getAllModelsFromOmniRoute()` — fetches `/v1/models` and converts to Pi model entries.
+11. `humanName()` — user-friendly labels for Ctrl+P.
 
 ## Prompt Tool Wire Format
 
@@ -152,12 +154,17 @@ Then update README example model JSON if user-visible.
 Update together:
 
 ```ts
-renderToolProtocol()
+selectPromptToolProtocol()
+renderFullToolProtocol()
+renderToolProtocolReminder()
 TOOL_CALL_RE
 renderToolCallBlock()
 parseToolCalls()
 README.md
+ARCHITECTURE.md
 ```
+
+Prompt protocol state is kept in `promptToolProtocolStates`, keyed by `options.sessionId`, provider, and model id. Keep it runtime-only; do not write prompt protocol text into flattened messages or saved session entries.
 
 ### Change setup behavior
 
@@ -185,7 +192,10 @@ import ok
 - Do not rely only on Pi runtime `Model` for `tool_calling`; custom fields and OmniRoute `owned_by` are stripped.
 - Do not set web/chat-only models to a separate provider; keep `/model` workflow unchanged.
 - Do not send native `tools` to chat-only web-synced models; use prompt mode with `tools: []`.
+- Do not filter extension/custom tools out of prompt mode unless explicitly requested; full protocol exposes every active tool.
 - `streamWithPromptTools()` is buffered, not token-streamed. It waits for full response so it can parse tool blocks safely.
+- Prompt protocol is ephemeral outbound system-prompt text. It must not be appended to `flattenMessages()` or persisted into Pi session history.
+- Reminder turns intentionally use compact argument hints, while full protocol refreshes every 6 prompt-tool turns, after tool-signature changes, and after parsing confusion.
 - Prompt mode drops non-text content in history because chat-only OpenAI-compatible endpoints here are treated as text-first.
 
 ## Current Branch Intent

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -73,13 +73,19 @@ Pi agent
   -> streamOmni(model, context, options)
   -> shouldUsePromptTools(model) === true
   -> streamWithPromptTools(model, context, options)
-  -> renderToolProtocol(context.tools)
+  -> selectPromptToolProtocol(model, context.tools, options)
+     -> full protocol on first prompt-tool turn
+     -> reminder protocol on steady-state turns
+     -> full protocol every 6 prompt-tool turns
+     -> full protocol when tool signature changes or parsing confusion occurs
   -> flattenMessages(context.messages)
   -> call openai-completions with tools: []
-  -> parse <tool_call> blocks from full text response
+  -> parse standalone <tool_call> blocks from full text response
   -> emit Pi-native toolcall_* stream events
   -> Pi executes tools
 ```
+
+The prompt-tool protocol is appended only to the outbound `systemPrompt` for the current provider request. It is not added to flattened messages and is not persisted into Pi's saved session history.
 
 ## Why `models.json` Is Re-read
 
@@ -121,9 +127,11 @@ Prompt mode uses this text protocol:
 Why XML-like tags:
 
 - easier to parse than arbitrary JSON in prose
-- allows normal answer text before tool call
 - supports multiple tool calls
 - can replay history using same structure
+- safe parser rule: tool calls execute only when the whole assistant message is `<tool_call>` block(s) plus whitespace
+
+Mixed prose plus `<tool_call>` is treated as normal text and does not execute tools. That protects documentation/examples from accidental execution.
 
 ## Stream Event Conversion
 
@@ -138,12 +146,29 @@ done(reason: "toolUse" | "stop")
 
 This makes Pi's normal agent loop execute tools, even though upstream model only wrote text.
 
+## Prompt Tool Protocol Refresh
+
+Prompt-tool protocol state is process-local and keyed by Pi's forwarded `options.sessionId`, provider, and model id. The state tracks the active tool signature, prompt-tool turn count, last full-protocol turn, and whether the next turn must force a full refresh.
+
+Full protocol includes every active Pi tool, including extension/custom tools, with compact descriptions and minified parameter schemas. Reminder protocol is much smaller but still includes compact parameter hints capped per tool, so stateless chat-completion requests still have argument shape guidance between full refreshes.
+
+Full protocol is sent when:
+
+- first prompt-tool turn for a session/model
+- active tool signature changes
+- 6 prompt-tool turns have passed since the last full protocol
+- previous response had malformed standalone tool JSON
+- previous response mixed prose with `<tool_call>` tags
+
+The state map is bounded to 1000 entries and evicts the oldest key when adding a new entry beyond the limit.
+
 ## Known Trade-offs
 
 - Prompt mode is buffered: it waits for full model output before parsing tool calls.
 - Images in history/tool results are dropped in prompt mode.
 - Small models may emit malformed JSON; parse errors are returned as visible assistant text so the model can self-correct next turn.
 - Prompt tool calls are only as reliable as model instruction following.
+- Reminder turns use compact parameter hints, not full descriptions, to reduce context cost between periodic full refreshes.
 
 ## API Key Handling
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The model is taught this wire format as a standalone assistant message:
 
 Prompt tool mode only executes tool calls when the entire assistant message is one or more `<tool_call>` blocks plus whitespace. If the model includes prose, examples, or any extra text alongside `<tool_call>`, the extension treats the whole response as normal text and does not execute tools. This prevents accidental tool calls from documentation snippets or mixed explanatory answers.
 
-To reduce context usage for web/chat-only models, the prompt-tool protocol is compact and refreshed periodically. The first prompt-tool request sends the full compact protocol with all active tools and minified parameter schemas. Later requests send only a tiny reminder with tool names, then the full protocol is sent again every 6 prompt-tool turns, whenever the active tool set changes, or after malformed/mixed tool-call output. The extension still exposes the full active Pi tool set in prompt-tool mode; it does not filter out extension/custom tools.
+To reduce context usage for web/chat-only models, the prompt-tool protocol is compact and refreshed periodically. The first prompt-tool request sends the full compact protocol with all active tools and minified parameter schemas. Later requests send a tiny reminder with compact argument hints, then the full protocol is sent again every 6 prompt-tool turns, whenever the active tool set changes, or after malformed/mixed tool-call output. The extension still exposes the full active Pi tool set in prompt-tool mode; it does not filter out extension/custom tools.
 
 Tool results are fed back in history as text:
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The model is taught this wire format as a standalone assistant message:
 
 Prompt tool mode only executes tool calls when the entire assistant message is one or more `<tool_call>` blocks plus whitespace. If the model includes prose, examples, or any extra text alongside `<tool_call>`, the extension treats the whole response as normal text and does not execute tools. This prevents accidental tool calls from documentation snippets or mixed explanatory answers.
 
-To reduce context usage for web/chat-only models, the prompt-tool protocol is compact: tools are listed on one line each with minified parameter schemas instead of expanded JSON Schema blocks. The extension still exposes the full active Pi tool set in prompt-tool mode; it does not filter out extension/custom tools.
+To reduce context usage for web/chat-only models, the prompt-tool protocol is compact and refreshed periodically. The first prompt-tool request sends the full compact protocol with all active tools and minified parameter schemas. Later requests send only a tiny reminder with tool names, then the full protocol is sent again every 6 prompt-tool turns, whenever the active tool set changes, or after malformed/mixed tool-call output. The extension still exposes the full active Pi tool set in prompt-tool mode; it does not filter out extension/custom tools.
 
 Tool results are fed back in history as text:
 

--- a/index.ts
+++ b/index.ts
@@ -205,11 +205,52 @@ function shouldUsePromptTools(model: Pick<Model<any>, "id" | "name" | "provider"
 	);
 }
 
-let protocolCache: { key: string; text: string } | undefined;
+const PROMPT_TOOL_FULL_REFRESH_TURNS = 6;
 
-/** Stable cache key for the active tool set; avoids rebuilding identical prompt protocol each turn. */
+type PromptToolProtocolState = {
+	toolSignature: string;
+	protocolId: string;
+	promptToolTurns: number;
+	lastFullProtocolTurn: number;
+	forceFullNextTurn: boolean;
+};
+
+type PromptToolProtocolSelection = {
+	text: string;
+	sentFull: boolean;
+};
+
+/**
+ * Runtime-only refresh state for prompt-tool instructions.
+ *
+ * Pi forwards `options.sessionId` to custom provider stream handlers, so we scope state by
+ * session + model. This keeps one session/model from borrowing stale refresh counters from
+ * another while avoiding any protocol persistence in the saved Pi conversation history.
+ */
+const promptToolProtocolStates = new Map<string, PromptToolProtocolState>();
+let fullProtocolCache: { key: string; text: string } | undefined;
+
+/** Stable cache key for the active tool set; any tool/schema change forces a fresh full protocol. */
 function toolsSignature(tools: Tool[]): string {
 	return JSON.stringify(tools.map((t) => [t.name, t.description, t.parameters]));
+}
+
+/** Small deterministic hash used only for human-readable protocol IDs in reminders. */
+function stableHash(input: string): string {
+	let hash = 2166136261;
+	for (let i = 0; i < input.length; i++) {
+		hash ^= input.charCodeAt(i);
+		hash = Math.imul(hash, 16777619);
+	}
+	return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function protocolIdForSignature(signature: string): string {
+	return `pi-tools-v1:${stableHash(signature)}`;
+}
+
+function promptToolStateKey(model: Model<any>, options?: SimpleStreamOptions): string {
+	return [options?.sessionId || "no-session", model.provider, model.id].join(":");
 }
 
 function compactToolDescription(description: unknown): string {
@@ -225,13 +266,21 @@ function compactToolParameters(parameters: unknown): string {
 	}
 }
 
-/** Render Pi's structured tools as compact text instructions for chat-only models. */
-function renderToolProtocol(tools: Tool[]): string {
-	const key = toolsSignature(tools);
-	if (protocolCache && protocolCache.key === key) return protocolCache.text;
+/**
+ * Render the full prompt-tool protocol.
+ *
+ * This contains every active Pi tool, including extension/custom tools, with compact minified
+ * parameter schemas. It is intentionally not placed into `messages`; it is only appended to the
+ * outbound system prompt for the current provider request.
+ */
+function renderFullToolProtocol(tools: Tool[], protocolId: string): string {
+	const signature = toolsSignature(tools);
+	const key = `full:${protocolId}:${signature}`;
+	if (fullProtocolCache && fullProtocolCache.key === key) return fullProtocolCache.text;
 
 	const lines: string[] = [
 		"# Pi prompt tools",
+		`Protocol id: ${protocolId}`,
 		"Native/internal tool calls are unavailable for this chat-only model.",
 		"To call tools, the entire assistant message must be only <tool_call> block(s), no prose/markdown/extra text.",
 		"If any extra text appears beside <tool_call>, it is normal text and no tool executes.",
@@ -248,8 +297,64 @@ function renderToolProtocol(tools: Tool[]): string {
 	}
 
 	const text = lines.join("\n");
-	protocolCache = { key, text };
+	fullProtocolCache = { key, text };
 	return text;
+}
+
+/**
+ * Render the cheap steady-state reminder.
+ *
+ * Most prompt-tool turns use this instead of repeating every schema. The full protocol is resent
+ * every PROMPT_TOOL_FULL_REFRESH_TURNS turns, whenever the tool set changes, or after parse
+ * confusion so chat-only web models can recover when they forget exact rules/arguments.
+ */
+function renderToolProtocolReminder(tools: Tool[], protocolId: string): string {
+	return [
+		"# Pi prompt tools reminder",
+		`Use protocol ${protocolId}.`,
+		"Tool call format: <tool_call>{\"name\":\"tool_name\",\"arguments\":{}}</tool_call>",
+		"Tool calls must be standalone assistant messages: no prose/markdown/extra text.",
+		"Extra text beside <tool_call> means no tool executes.",
+		`Available tool names: ${tools.map((tool) => tool.name).join(", ")}`,
+	].join("\n");
+}
+
+/** Choose full vs reminder protocol for this session/model/tool set and advance turn state. */
+function selectPromptToolProtocol(
+	model: Model<any>,
+	tools: Tool[],
+	options?: SimpleStreamOptions,
+): PromptToolProtocolSelection {
+	const key = promptToolStateKey(model, options);
+	const signature = toolsSignature(tools);
+	const protocolId = protocolIdForSignature(signature);
+	const current = promptToolProtocolStates.get(key);
+	const nextTurn = current ? current.promptToolTurns + 1 : 1;
+	const toolSetChanged = !current || current.toolSignature !== signature;
+	const refreshDue = current
+		? nextTurn - current.lastFullProtocolTurn >= PROMPT_TOOL_FULL_REFRESH_TURNS
+		: true;
+	const sendFull = toolSetChanged || refreshDue || current?.forceFullNextTurn === true;
+
+	promptToolProtocolStates.set(key, {
+		toolSignature: signature,
+		protocolId,
+		promptToolTurns: nextTurn,
+		lastFullProtocolTurn: sendFull ? nextTurn : current?.lastFullProtocolTurn ?? nextTurn,
+		forceFullNextTurn: false,
+	});
+
+	return {
+		text: sendFull
+			? renderFullToolProtocol(tools, protocolId)
+			: renderToolProtocolReminder(tools, protocolId),
+		sentFull: sendFull,
+	};
+}
+
+function forceFullProtocolNextTurn(model: Model<any>, options?: SimpleStreamOptions): void {
+	const state = promptToolProtocolStates.get(promptToolStateKey(model, options));
+	if (state) state.forceFullNextTurn = true;
 }
 
 /** Extract text blocks and drop unsupported content like images for plain chat endpoints. */
@@ -326,22 +431,32 @@ function coerceArguments(value: unknown): Record<string, any> {
 	return {};
 }
 
-/** Parse standalone <tool_call> messages and preserve parse errors as model-visible feedback. */
-function parseToolCalls(text: string): {
+type ParseToolCallsResult = {
 	prose: string;
 	calls: { name: string; arguments: Record<string, any> }[];
 	errors: string[];
-} {
+	mixedToolCallText: boolean;
+};
+
+/**
+ * Parse standalone <tool_call> messages and preserve parse errors as model-visible feedback.
+ *
+ * Mixed prose + <tool_call> remains safe: it is returned as normal prose and no tool executes.
+ * The `mixedToolCallText` flag lets the next turn re-send the full protocol so the model can
+ * recover from that confusion without showing noisy warnings for documentation/examples.
+ */
+function parseToolCalls(text: string): ParseToolCallsResult {
 	const calls: { name: string; arguments: Record<string, any> }[] = [];
 	const errors: string[] = [];
 	const original = text.trim();
-	if (!original) return { prose: "", calls, errors };
+	if (!original) return { prose: "", calls, errors, mixedToolCallText: false };
 
+	const hasToolCallText = /<tool_call>[\s\S]*?<\/tool_call>/.test(text);
 	TOOL_CALL_RE.lastIndex = 0;
 	const remainder = text.replace(TOOL_CALL_RE, "").trim();
 	if (remainder) {
 		// Safety: examples or accidental <tool_call> snippets in prose must not execute.
-		return { prose: original, calls: [], errors: [] };
+		return { prose: original, calls: [], errors: [], mixedToolCallText: hasToolCallText };
 	}
 
 	let match: RegExpExecArray | null;
@@ -360,8 +475,10 @@ function parseToolCalls(text: string): {
 		}
 	}
 
-	if (calls.length === 0 && errors.length === 0) return { prose: original, calls, errors };
-	return { prose: "", calls, errors };
+	if (calls.length === 0 && errors.length === 0) {
+		return { prose: original, calls, errors, mixedToolCallText: false };
+	}
+	return { prose: "", calls, errors, mixedToolCallText: false };
 }
 
 /**
@@ -398,9 +515,14 @@ function streamWithPromptTools(
 			stream.push({ type: "start", partial: output });
 
 			const tools = context.tools ?? [];
+			const protocol = tools.length > 0
+				? selectPromptToolProtocol(model, tools, options)
+				: undefined;
 			const innerContext: Context = {
-				systemPrompt: tools.length > 0
-					? `${context.systemPrompt ?? ""}\n\n${renderToolProtocol(tools)}`.trim()
+				// Prompt-tool protocol stays ephemeral: it is appended only to this outbound
+				// provider request, never to flattened message history or saved Pi session entries.
+				systemPrompt: protocol
+					? `${context.systemPrompt ?? ""}\n\n${protocol.text}`.trim()
 					: context.systemPrompt,
 				messages: flattenMessages(context.messages),
 				tools: [],
@@ -426,8 +548,14 @@ function streamWithPromptTools(
 			}
 
 			const rawText = textOf(innerResult.content as TextContent[]);
-			const parsed = tools.length > 0 ? parseToolCalls(rawText) : { prose: rawText, calls: [], errors: [] as string[] };
+			const parsed = tools.length > 0
+				? parseToolCalls(rawText)
+				: { prose: rawText, calls: [], errors: [] as string[], mixedToolCallText: false };
 			let prose = parsed.prose;
+
+			if (parsed.errors.length > 0 || parsed.mixedToolCallText) {
+				forceFullProtocolNextTurn(model, options);
+			}
 
 			if (parsed.errors.length > 0) {
 				const note = [

--- a/index.ts
+++ b/index.ts
@@ -206,6 +206,7 @@ function shouldUsePromptTools(model: Pick<Model<any>, "id" | "name" | "provider"
 }
 
 const PROMPT_TOOL_FULL_REFRESH_TURNS = 6;
+const PROMPT_TOOL_MAX_STATE_ENTRIES = 1000;
 
 type PromptToolProtocolState = {
 	toolSignature: string;
@@ -217,7 +218,6 @@ type PromptToolProtocolState = {
 
 type PromptToolProtocolSelection = {
 	text: string;
-	sentFull: boolean;
 };
 
 /**
@@ -308,6 +308,14 @@ function renderFullToolProtocol(tools: Tool[], protocolId: string): string {
  * every PROMPT_TOOL_FULL_REFRESH_TURNS turns, whenever the tool set changes, or after parse
  * confusion so chat-only web models can recover when they forget exact rules/arguments.
  */
+function compactToolReminderHint(tool: Tool): string {
+	const parameters = compactToolParameters(tool.parameters);
+	const cappedParameters = parameters.length > 300
+		? `${parameters.slice(0, 300)}...`
+		: parameters;
+	return `${tool.name} parameters=${cappedParameters}`;
+}
+
 function renderToolProtocolReminder(tools: Tool[], protocolId: string): string {
 	return [
 		"# Pi prompt tools reminder",
@@ -315,7 +323,8 @@ function renderToolProtocolReminder(tools: Tool[], protocolId: string): string {
 		"Tool call format: <tool_call>{\"name\":\"tool_name\",\"arguments\":{}}</tool_call>",
 		"Tool calls must be standalone assistant messages: no prose/markdown/extra text.",
 		"Extra text beside <tool_call> means no tool executes.",
-		`Available tool names: ${tools.map((tool) => tool.name).join(", ")}`,
+		"Compact argument hints:",
+		...tools.map(compactToolReminderHint),
 	].join("\n");
 }
 
@@ -336,6 +345,13 @@ function selectPromptToolProtocol(
 		: true;
 	const sendFull = toolSetChanged || refreshDue || current?.forceFullNextTurn === true;
 
+	// Pi extension hosts can live for many sessions. Bound the process-local state map so
+	// refresh counters remain useful without growing indefinitely across old sessions.
+	if (promptToolProtocolStates.size >= PROMPT_TOOL_MAX_STATE_ENTRIES && !promptToolProtocolStates.has(key)) {
+		const oldestKey = promptToolProtocolStates.keys().next().value;
+		if (oldestKey !== undefined) promptToolProtocolStates.delete(oldestKey);
+	}
+
 	promptToolProtocolStates.set(key, {
 		toolSignature: signature,
 		protocolId,
@@ -348,7 +364,6 @@ function selectPromptToolProtocol(
 		text: sendFull
 			? renderFullToolProtocol(tools, protocolId)
 			: renderToolProtocolReminder(tools, protocolId),
-		sentFull: sendFull,
 	};
 }
 
@@ -451,7 +466,8 @@ function parseToolCalls(text: string): ParseToolCallsResult {
 	const original = text.trim();
 	if (!original) return { prose: "", calls, errors, mixedToolCallText: false };
 
-	const hasToolCallText = /<tool_call>[\s\S]*?<\/tool_call>/.test(text);
+	const openIdx = text.indexOf("<tool_call>");
+	const hasToolCallText = openIdx !== -1 && text.indexOf("</tool_call>", openIdx) !== -1;
 	TOOL_CALL_RE.lastIndex = 0;
 	const remainder = text.replace(TOOL_CALL_RE, "").trim();
 	if (remainder) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute-pi-ext-integration",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute-pi-ext-integration",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute-pi-ext-integration",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Pi Coding Agent extension for OmniRoute — view combos, browse providers, and sync models with enriched metadata (context windows, max tokens, reasoning, and vision) to the Ctrl+P picker",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Superseded by #5 — the prompt-tool refresh logic from this branch has been ported into `shared.ts` on the `claude/repo-merge-compatibility-nV9De` branch, which merges omp+pi support into a single package and targets `main` directly. All reviewer concerns raised here were already addressed in this branch's commits; the port carries them over verbatim.