### PR TITLE
Normalize legacy Pi catalogs during migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 ```bash
 npm install
 npm run typecheck
+npm test
 npm run smoke
 ```
 
@@ -12,24 +13,20 @@ npm run smoke
 
 | Command | Purpose |
 |---|---|
-| `npm run typecheck` | Type-check `index.ts` with NodeNext settings. |
-| `npm run smoke` | Import the extension module and verify it loads. |
+| `npm run typecheck` | Type-check both host entrypoints, shared code, and tests with NodeNext settings. |
+| `npm test` | Run the focused Node test suite. |
+| `npm run smoke` | Import both Pi and OMP entrypoints and verify they load. |
 
-## Local Pi Testing
+## Local Testing
 
-From this repo:
-
-```bash
-pi -e ./index.ts
-```
-
-Or install normally:
+Link the checkout into either host:
 
 ```bash
-pi install git:github.com/md-riaz/omniroute-pi-ext-integration
+pi install /absolute/path/to/omniroute-agent-extension
+omp plugin link /absolute/path/to/omniroute-agent-extension
 ```
 
-Then in Pi:
+Then in Pi or OMP:
 
 ```text
 /omni setup
@@ -43,6 +40,7 @@ Run:
 
 ```bash
 npm run typecheck
+npm test
 npm run smoke
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ pi install omniroute-agent-extension
 pi install git:github.com/md-riaz/omniroute-agent-extension
 ```
 
+When replacing the earlier Pi-only `omniroute-pi-ext-integration`, existing `omni` catalog entries are normalized automatically on first load. Run `/omni sync` afterward to refresh the catalog from the server.
+
 ## Getting Started
 
 1. Start your CLI (`pi` or `omp`)

--- a/omp.ts
+++ b/omp.ts
@@ -1,7 +1,6 @@
-import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
-import { createOmniExtension } from "./shared.ts";
+import { createOmniExtension, type OmniPI } from "./shared.ts";
 
-export default async function (pi: ExtensionAPI): Promise<void> {
+export default async function (pi: OmniPI): Promise<void> {
   await createOmniExtension(pi, {
     homeEnvVar: "OMP_HOME",
     defaultHome: "~/.omp/agent",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omniroute-agent-extension",
   "version": "3.1.0",
-  "description": "OmniRoute extension for Pi Coding Agent (pi) and Oh My Pi (omp) — model sync and prompt-tool fallback for chat-only models",
+  "description": "OmniRoute extension for Pi Coding Agent (pi) and Oh My Pi (omp) — model sync, health checks, and native host routing",
   "keywords": [
     "omp-plugin",
     "oh-my-pi",
@@ -31,7 +31,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit --allowImportingTsExtensions --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --types node shared.ts omp.ts pi.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "node --experimental-strip-types --test test/*.test.ts",
     "smoke": "node --experimental-strip-types -e \"import('./omp.ts').then(()=>console.log('omp ok')).catch(e=>{console.error(e);process.exit(1)})\" && node --experimental-strip-types -e \"import('./pi.ts').then(()=>console.log('pi ok')).catch(e=>{console.error(e);process.exit(1)})\""
   },
   "author": "md-riaz",

--- a/pi.ts
+++ b/pi.ts
@@ -1,7 +1,6 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { createOmniExtension } from "./shared.ts";
+import { createOmniExtension, type OmniPI } from "./shared.ts";
 
-export default async function (pi: ExtensionAPI): Promise<void> {
+export default async function (pi: OmniPI): Promise<void> {
   await createOmniExtension(pi, {
     homeEnvVar: "PI_HOME",
     defaultHome: "~/.pi/agent",

--- a/shared.ts
+++ b/shared.ts
@@ -320,7 +320,7 @@ function reloadProviderFromModelsJson(pi: OmniPI, agentHome: string, config: Omn
 				? provider.models.map((model: any) => ({
 						...model,
 						api: PROVIDER_API,
-						cost: model.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, ...model.cost },
 					}))
 				: provider.models,
 		});

--- a/shared.ts
+++ b/shared.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 // ─── Local CLI interface — no import from either CLI package ──────────────────
-interface OmniPI {
+export interface OmniPI {
 	registerProvider(name: string, config: any): void;
 	registerTool(tool: {
 		name: string;
@@ -313,7 +313,17 @@ function reloadProviderFromModelsJson(pi: OmniPI, agentHome: string, config: Omn
 	try {
 		const provider = readModelsJson(agentHome)?.providers?.[config.providerName];
 		if (!provider) return;
-		pi.registerProvider(config.providerName, provider);
+		pi.registerProvider(config.providerName, {
+			...provider,
+			api: PROVIDER_API,
+			models: Array.isArray(provider.models)
+				? provider.models.map((model: any) => ({
+						...model,
+						api: PROVIDER_API,
+						cost: model.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					}))
+				: provider.models,
+		});
 	} catch {}
 }
 

--- a/test/shared.test.ts
+++ b/test/shared.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createOmniExtension } from "../shared.ts";
+
+test("normalizes legacy Pi catalog API identifiers when reloading models.json", async () => {
+  const agentHome = mkdtempSync(join(tmpdir(), "omniroute-agent-extension-test-"));
+  const envName = "OMNIROUTE_TEST_HOME";
+  const previousHome = process.env[envName];
+  process.env[envName] = agentHome;
+
+  writeFileSync(
+    join(agentHome, "models.json"),
+    JSON.stringify({
+      providers: {
+        omni: {
+          baseUrl: "http://127.0.0.1:20128/v1",
+          apiKey: "test-key",
+          api: "omni-prompt-tools",
+          models: [{ id: "gpt-test", name: "GPT Test", api: "omni-prompt-tools" }],
+        },
+      },
+    }),
+  );
+
+  const registrations: Array<{ name: string; config: any }> = [];
+  const pi = {
+    registerProvider(name: string, config: any) {
+      registrations.push({ name, config });
+    },
+    registerTool() {},
+    registerCommand() {},
+    on() {},
+  };
+
+  try {
+    await createOmniExtension(pi, { homeEnvVar: envName, defaultHome: "~/.unused" });
+
+    assert.equal(registrations.length, 1);
+    assert.equal(registrations[0].name, "omni");
+    assert.equal(registrations[0].config.api, "openai-completions");
+    assert.equal(registrations[0].config.models[0].api, "openai-completions");
+    assert.deepEqual(registrations[0].config.models[0].cost, {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+  } finally {
+    if (previousHome === undefined) delete process.env[envName];
+    else process.env[envName] = previousHome;
+    rmSync(agentHome, { recursive: true, force: true });
+  }
+});

--- a/test/shared.test.ts
+++ b/test/shared.test.ts
@@ -19,7 +19,15 @@ test("normalizes legacy Pi catalog API identifiers when reloading models.json", 
           baseUrl: "http://127.0.0.1:20128/v1",
           apiKey: "test-key",
           api: "omni-prompt-tools",
-          models: [{ id: "gpt-test", name: "GPT Test", api: "omni-prompt-tools" }],
+          models: [
+            { id: "gpt-test", name: "GPT Test", api: "omni-prompt-tools" },
+            {
+              id: "gpt-partial-cost",
+              name: "GPT Partial Cost",
+              api: "omni-prompt-tools",
+              cost: { input: 1.25 },
+            },
+          ],
         },
       },
     }),
@@ -44,6 +52,12 @@ test("normalizes legacy Pi catalog API identifiers when reloading models.json", 
     assert.equal(registrations[0].config.models[0].api, "openai-completions");
     assert.deepEqual(registrations[0].config.models[0].cost, {
       input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+    assert.deepEqual(registrations[0].config.models[1].cost, {
+      input: 1.25,
       output: 0,
       cacheRead: 0,
       cacheWrite: 0,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["shared.ts", "omp.ts", "pi.ts", "test/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "allowImportingTsExtensions": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "noEmit": true,
     "skipLibCheck": true,
     "target": "ES2022",
     "types": ["node"]


### PR DESCRIPTION
Closes #8.

## Summary

- normalize legacy `omni-prompt-tools` provider/model entries to `openai-completions` at startup
- provide the existing zero-cost default when legacy models omit `cost`
- use the shared host-neutral extension API type for Pi and OMP entrypoints
- add a focused migration test and a project `tsconfig.json`
- minimally update migration, contributor, and package-homepage documentation

## Validation

- `npm run typecheck`
- `npm test`
- `npm run smoke` — `omp ok`, `pi ok`
- real Pi request through `omni/gpt-5.6-sol` succeeds
- real OMP request through `omni/gpt-5.6-sol` succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically normalizes legacy Omni catalog entries on first load; run `/omni sync` afterward to refresh the catalog.
  - Improved provider and model configuration handling, including default cost information.

- **Documentation**
  - Expanded setup, local testing, development script, and pull request guidance.
  - Updated package documentation to reflect model synchronization, health checks, and native host routing.

- **Tests**
  - Added coverage for legacy catalog normalization and model defaults.
  - Simplified test and type-check commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->