### PR TITLE
feat: land 3.2.0 catalog autosync on parent main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Run:
 
 ```bash
 npm run typecheck
+npm test
 npm run smoke
 ```
 
@@ -67,7 +68,7 @@ If tests cannot run, report exact command and failure.
 
 - Prefer small targeted edits.
 - Keep comments on non-obvious functions.
-- Preserve `/omni setup`, `/omni sync`, `/omni dashboard` behavior unless user asks to change it.
+- Preserve `/omni setup`, `/omni sync`, `/omni dashboard`, `/omni autosync` behavior unless user asks to change it.
 - Keep prompt-tool format and parser docs in sync.
 - If adding files, update `AI.md` file map.
 
@@ -75,7 +76,8 @@ If tests cannot run, report exact command and failure.
 
 | File | Why important |
 |---|---|
-| `index.ts` | Extension implementation. |
+| `shared.ts` | Extension implementation (commands, catalog sync/autosync, provider). |
+| `scripts/sync-once.ts` | One-shot catalog sync helper. |
 | `AI.md` | AI scan guide; update when project structure/function map changes. |
 | `ARCHITECTURE.md` | Data flow and tool routing docs. |
 | `README.md` | User-facing documentation. |

--- a/AI.md
+++ b/AI.md
@@ -18,7 +18,11 @@ It does three jobs:
 
 | Path | Purpose |
 |---|---|
-| `index.ts` | Entire extension implementation. Commands, sync, provider registration, prompt-tool fallback. |
+| `shared.ts` | Extension implementation. Commands, catalog sync/autosync, provider registration. |
+| `omp.ts` | Oh My Pi entry point. |
+| `pi.ts` | Pi Coding Agent entry point. |
+| `scripts/sync-once.ts` | One-shot catalog sync helper for install/refresh scripts. |
+| `test/shared.test.ts` | Legacy catalog migration and autosync unit tests. |
 | `README.md` | User-facing install/setup/usage docs. |
 | `package.json` | Pi extension metadata, scripts, dev deps. |
 | `package-lock.json` | Locked npm dependency tree. |
@@ -90,19 +94,15 @@ Prompt tool mode triggers when:
 
 Reason: Pi's runtime `Model` type does not preserve custom fields like `tool_calling`, so the extension re-reads raw `models.json` in `modelConfigToolCallingFalse()`.
 
-## Important Functions In `index.ts`
+## Important Functions In `shared.ts`
 
 Read in this order:
 
-1. `registerOmniProvider()` — registers/refreshes the `omni` provider and model list.
-2. `streamOmni()` — runtime router for native vs prompt tool mode.
-3. `shouldUsePromptTools()` — decides if prompt tool fallback is needed.
-4. `streamWithPromptTools()` — prompt-tool stream implementation.
-5. `renderToolProtocol()` — converts Pi tool schemas into prompt text.
-6. `flattenMessages()` — converts native tool history into text history for chat-only models.
-7. `parseToolCalls()` — parses `<tool_call>` blocks from model output.
-8. `getAllModelsFromOmniRoute()` — fetches `/v1/models` and converts to Pi model entries.
-9. `humanName()` — user-friendly labels for Ctrl+P.
+1. `createOmniExtension()` — registers commands, tools, health checks, and catalog autosync.
+2. `registerOmniProvider()` — registers/refreshes the `omni` provider and model list.
+3. `sanitizeAutoSyncIntervalMs()` — clamps `/omni autosync` and env interval values.
+4. `syncOmniModelsForAgentHome()` — one-shot sync used by `scripts/sync-once.ts`.
+5. `getAllModelsFromOmniRoute()` — fetches `/v1/models` and converts to Pi model entries.
 
 ## Prompt Tool Wire Format
 
@@ -165,19 +165,21 @@ Update `/omni setup` handler near bottom of `index.ts`. Preserve the current ord
 
 ### Change sync behavior
 
-Update `/omni sync` handler and `getAllModelsFromOmniRoute()`.
+Update `/omni sync`, catalog autosync (`startAutoSync` / `sanitizeAutoSyncIntervalMs`), and `getAllModelsFromOmniRoute()`. Keep `/omni autosync` as the user control; do not add a second provider.
 
 ## Test Commands
 
 ```bash
 npm run typecheck
+npm test
 npm run smoke
 ```
 
 Expected smoke output:
 
 ```text
-import ok
+omp ok
+pi ok
 ```
 
 ## Pitfalls

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,6 +53,29 @@ Saved provider shape:
   -> re-register omni provider
 ```
 
+## Data Flow: Catalog Autosync
+
+Manual `/omni sync` is unchanged. When catalog autosync is enabled (default 5 minutes; `0` disables):
+
+```text
+session_start (reachable + autosync on)
+  -> sync() fetches /v1/models and re-registers omni
+  -> startAutoSync() sets a background interval
+  -> quiet interval syncs refresh the picker
+  -> notify only when the catalog count changes
+session_shutdown
+  -> stopAutoSync()
+```
+
+Control:
+
+```text
+/omni autosync on|off|status|<ms>|<Ns|Nm|Nh>
+OMNIROUTE_AUTO_SYNC_INTERVAL_MS
+```
+
+`sanitizeAutoSyncIntervalMs()` clamps values below 60s up to 60s. Concurrent syncs share one in-flight promise. `scripts/sync-once.ts` calls `syncOmniModelsForAgentHome()` for one-shot installer refresh.
+
 ## Data Flow: Native Tool Model
 
 ```text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,8 @@ For model sync changes:
 
 - `/omni setup` saves URL/API key.
 - `/omni sync` writes models to `~/.pi/agent/models.json`.
+- Catalog autosync re-fetches `/v1/models` on session start and on the configured interval.
+- `/omni autosync off` disables background discovery; manual `/omni sync` still works.
 - Web-synced models get `tool_calling:false` even when `-web` only appears in OmniRoute `owned_by`/provider metadata.
 - Normal models do not get forced into prompt mode.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Connect to your local or remote OmniRoute server and route queries across 44+ LL
 - **Smart sorting** — models grouped by provider prefix, auto-routing models (`auto`, `auto/coding`, etc.) always first.
 - **Health monitoring** — periodic reachability checks with status bar indicators.
 - **Connection log** — every failed or abnormally slow connection attempt is appended as a JSON line to `<agent-home>/<state>/connection.log` for infra debugging; `ms` timings expose server cold starts, error fields include the fetch `cause` (e.g. `ECONNRESET`, `ETIMEDOUT`, TLS errors).
-- **Env overrides** — `OMNIROUTE_URL`, `OMNIROUTE_API_KEY`, `OMNIROUTE_PROVIDER_NAME` skip the setup wizard entirely.
+- **Catalog autosync** — while the harness is running, re-fetch `/v1/models` on session start and on a configurable interval (default 5 minutes). Manual `/omni sync` still works anytime; control with `/omni autosync on|off|<interval>`.
+- **Env overrides** — `OMNIROUTE_URL`, `OMNIROUTE_API_KEY`, and `OMNIROUTE_PROVIDER_NAME` skip the setup wizard entirely. `OMNIROUTE_AUTO_SYNC_INTERVAL_MS` overrides the catalog autosync interval.
 
 ## Installation
 
@@ -46,7 +47,7 @@ When replacing the earlier Pi-only `omniroute-pi-ext-integration`, existing `omn
 
 1. Start your CLI (`pi` or `omp`)
 2. Run `/omni setup` — enter your OmniRoute server URL and API key
-3. Run `/omni sync` — populates the `Ctrl+P` / `/model` picker
+3. Run `/omni sync` — populates the `Ctrl+P` / `/model` picker (optional after first session; catalog autosync also runs on session start)
 4. Select any model with `/model` and start chatting
 
 Config is saved to:
@@ -70,6 +71,7 @@ Synced models are written to `~/.omp/agent/models.json` (or `~/.pi/agent/models.
 | `/omni test <model>` | Smoke-test `/v1/chat/completions` with a specific model |
 | `/omni dashboard` | Show the OmniRoute dashboard URL |
 | `/omni config` | Show config, models.json, and connection log paths with current settings |
+| `/omni autosync [on\|off\|status\|<interval>]` | Enable, disable, or set background catalog discovery (default 5m) |
 | `/omni help` | Show command list |
 
 ## Agent Tools
@@ -107,13 +109,15 @@ auto/cheap   auto/offline   auto/smart   auto/lkgp
 | `OMNIROUTE_URL` | OmniRoute server base URL |
 | `OMNIROUTE_API_KEY` | API key |
 | `OMNIROUTE_PROVIDER_NAME` | Provider name shown in the picker (default: `omni`) |
+| `OMNIROUTE_AUTO_SYNC_INTERVAL_MS` | Background catalog re-fetch interval in milliseconds. `0` disables autosync. Default `300000` (5 minutes). Minimum `60000`. |
 
-When any of these are set, `/omni setup` is not required.
+When `OMNIROUTE_URL`, `OMNIROUTE_API_KEY`, or `OMNIROUTE_PROVIDER_NAME` are set, `/omni setup` is not required.
 
 ## Development
 
 ```bash
 npm run typecheck   # tsc — zero errors expected
+npm test            # Node test suite (legacy catalog + autosync)
 npm run smoke       # import check for omp.ts and pi.ts
 ```
 
@@ -122,6 +126,7 @@ npm run smoke       # import check for omp.ts and pi.ts
 | `shared.ts` | All business logic — no host package imports; works in both `pi` and `omp` |
 | `omp.ts` | Oh My Pi entry point — `OMP_HOME` / `~/.omp/agent` |
 | `pi.ts` | Pi Coding Agent entry point — `PI_HOME` / `~/.pi/agent` |
+| `scripts/sync-once.ts` | One-shot catalog sync helper for install/refresh scripts |
 
 ## Requirements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.60.0",
-        "@oh-my-pi/pi-coding-agent": ">=0.60.0"
+        "@oh-my-pi/pi-coding-agent": ">=15.9.0"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-coding-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute-agent-extension",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute-agent-extension",
-      "version": "3.0.0",
+      "version": "3.2.0",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "^15.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omniroute-agent-extension",
-  "version": "3.1.0",
-  "description": "OmniRoute extension for Pi Coding Agent (pi) and Oh My Pi (omp) — model sync, health checks, and native host routing",
+  "version": "3.2.0",
+  "description": "OmniRoute extension for Pi Coding Agent (pi) and Oh My Pi (omp) — model sync, health checks, catalog autosync, and native host routing",
   "keywords": [
     "omp-plugin",
     "oh-my-pi",

--- a/scripts/sync-once.ts
+++ b/scripts/sync-once.ts
@@ -1,0 +1,26 @@
+import { syncOmniModelsForAgentHome } from "../shared.ts";
+
+const homeEnvVar = process.argv[2] || "PI_HOME";
+const defaultHome = process.argv[3] || "~/.pi/agent";
+
+const registrations: any[] = [];
+const pi = {
+  registerProvider(name: string, config: any) {
+    registrations.push({ name, config });
+  },
+  registerTool() {},
+  registerCommand() {},
+  on() {},
+};
+
+const count = await syncOmniModelsForAgentHome(pi as any, {
+  homeEnvVar,
+  defaultHome,
+});
+console.log(
+  JSON.stringify({
+    ok: true,
+    count,
+    provider: registrations[0]?.name || null,
+  }),
+);

--- a/shared.ts
+++ b/shared.ts
@@ -34,6 +34,8 @@ interface OmniConfig {
 	serverUrl: string;
 	apiKey: string;
 	providerName: string;
+	/** Background model re-discovery interval while the harness is running (ms). 0 disables. Default 300000 (5m). */
+	autoSyncIntervalMs?: number;
 }
 
 interface OmniApiModel {
@@ -83,7 +85,10 @@ const DEFAULT_CONFIG: OmniConfig = {
 	serverUrl: "http://127.0.0.1:20128",
 	apiKey: "",
 	providerName: "omni",
+	autoSyncIntervalMs: 300_000,
 };
+const MIN_AUTO_SYNC_INTERVAL_MS = 60_000;
+const DEFAULT_AUTO_SYNC_INTERVAL_MS = 300_000;
 
 // ─── Path helpers ─────────────────────────────────────────────────────────────
 function resolveAgentHome(opts: AgentHomeOptions): string {
@@ -148,11 +153,24 @@ function normalizeServerUrl(value: string): string {
 	return url || DEFAULT_CONFIG.serverUrl;
 }
 
-function sanitizeConfig(input: Partial<OmniConfig>): OmniConfig {
+export function sanitizeAutoSyncIntervalMs(value: unknown): number {
+	if (value === undefined || value === null || value === "") {
+		return DEFAULT_AUTO_SYNC_INTERVAL_MS;
+	}
+	const n = typeof value === "number" ? value : Number(String(value).trim());
+	if (!Number.isFinite(n) || n < 0) return DEFAULT_AUTO_SYNC_INTERVAL_MS;
+	if (n === 0) return 0; // explicit disable
+	return Math.max(MIN_AUTO_SYNC_INTERVAL_MS, Math.floor(n));
+}
+
+export function sanitizeConfig(input: Partial<OmniConfig>): OmniConfig {
 	return {
 		serverUrl: normalizeServerUrl(String(input.serverUrl || DEFAULT_CONFIG.serverUrl)),
 		apiKey: String(input.apiKey ?? ""),
 		providerName: String(input.providerName || DEFAULT_CONFIG.providerName).trim() || DEFAULT_CONFIG.providerName,
+		autoSyncIntervalMs: sanitizeAutoSyncIntervalMs(
+			input.autoSyncIntervalMs ?? process.env.OMNIROUTE_AUTO_SYNC_INTERVAL_MS ?? DEFAULT_CONFIG.autoSyncIntervalMs,
+		),
 	};
 }
 
@@ -161,6 +179,9 @@ function loadConfig(agentHome: string): OmniConfig {
 	if (process.env.OMNIROUTE_URL) env.serverUrl = process.env.OMNIROUTE_URL;
 	if (process.env.OMNIROUTE_API_KEY) env.apiKey = process.env.OMNIROUTE_API_KEY;
 	if (process.env.OMNIROUTE_PROVIDER_NAME) env.providerName = process.env.OMNIROUTE_PROVIDER_NAME;
+	if (process.env.OMNIROUTE_AUTO_SYNC_INTERVAL_MS !== undefined) {
+		env.autoSyncIntervalMs = sanitizeAutoSyncIntervalMs(process.env.OMNIROUTE_AUTO_SYNC_INTERVAL_MS);
+	}
 	try {
 		return sanitizeConfig({ ...DEFAULT_CONFIG, ...JSON.parse(readFileSync(configPath(agentHome), "utf8")), ...env });
 	} catch {
@@ -475,6 +496,11 @@ function modelLines(models: ProviderModelConfig[], query = "", limit = 80): stri
 async function showStatus(ctx: any, agentHome: string, config: OmniConfig): Promise<void> {
 	const ok = await checkHealth(agentHome, config, "status");
 	const configured = existsSync(configPath(agentHome));
+	const interval = sanitizeAutoSyncIntervalMs(config.autoSyncIntervalMs);
+	const autoSync =
+		interval === 0
+			? "off"
+			: `every ${Math.round(interval / 1000)}s (session start + background)`;
 	ctx.ui.notify(
 		[
 			"OmniRoute Status",
@@ -483,6 +509,7 @@ async function showStatus(ctx: any, agentHome: string, config: OmniConfig): Prom
 			`Provider:   ${config.providerName}`,
 			`Health:     ${ok ? "reachable" : "unreachable"}`,
 			`Configured: ${configured ? "yes" : "no — run /omni setup"}`,
+			`Auto-sync:  ${autoSync}`,
 		].join("\n"),
 		ok ? "info" : "warning",
 	);
@@ -500,6 +527,7 @@ function helpText(): string {
 		"/omni test <model>     Smoke-test /v1/chat/completions",
 		"/omni dashboard        Show OmniRoute dashboard URL",
 		"/omni config           Show config paths and current settings",
+		"/omni autosync [ms|off|on|status]  Background model discovery while running",
 		"/omni help             Show this help",
 	].join("\n");
 }
@@ -554,19 +582,73 @@ export async function createOmniExtension(pi: OmniPI, opts: AgentHomeOptions): P
 	const agentHome = resolveAgentHome(opts);
 	let config = loadConfig(agentHome);
 	let healthTimer: ReturnType<typeof setInterval> | undefined;
+	let autoSyncTimer: ReturnType<typeof setInterval> | undefined;
+	let lastSyncCount = 0;
+	let lastSyncAt: string | null = null;
+	let syncInFlight: Promise<number> | null = null;
+	let sessionCtx: any | undefined;
 
-	async function sync(ctx?: any): Promise<number> {
+	function formatAutoSync(intervalMs: number | undefined): string {
+		const interval = sanitizeAutoSyncIntervalMs(intervalMs);
+		if (interval === 0) return "off";
+		return `every ${Math.round(interval / 1000)}s`;
+	}
+
+	async function sync(ctx?: any, options?: { quiet?: boolean }): Promise<number> {
+		if (syncInFlight) return syncInFlight;
+		const quiet = options?.quiet === true;
+		syncInFlight = (async () => {
+			try {
+				config = loadConfig(agentHome);
+				const models = await registerOmniProvider(pi, agentHome, config);
+				const previousCount = lastSyncCount;
+				lastSyncCount = models.length;
+				lastSyncAt = new Date().toISOString();
+				const notifyCtx = ctx ?? sessionCtx;
+				(notifyCtx as any)?.modelRegistry?.refresh?.();
+				if (!quiet) {
+					notifyCtx?.ui.notify(`OmniRoute synced ${models.length} model(s).`, "info");
+				} else if (previousCount > 0 && previousCount !== models.length) {
+					notifyCtx?.ui.notify(
+						`OmniRoute auto-sync: catalog ${previousCount} → ${models.length} model(s).`,
+						"info",
+					);
+				}
+				return models.length;
+			} finally {
+				syncInFlight = null;
+			}
+		})();
+		return syncInFlight;
+	}
+
+	function stopAutoSync(): void {
+		if (autoSyncTimer) clearInterval(autoSyncTimer);
+		autoSyncTimer = undefined;
+	}
+
+	function startAutoSync(ctx: any): void {
+		stopAutoSync();
+		sessionCtx = ctx;
 		config = loadConfig(agentHome);
-		const models = await registerOmniProvider(pi, agentHome, config);
-		;(ctx as any)?.modelRegistry?.refresh?.();
-		ctx?.ui.notify(`OmniRoute synced ${models.length} model(s).`, "info");
-		return models.length;
+		const interval = sanitizeAutoSyncIntervalMs(config.autoSyncIntervalMs);
+		if (interval === 0) return;
+		autoSyncTimer = setInterval(() => {
+			void sync(sessionCtx, { quiet: true }).catch((error) => {
+				sessionCtx?.ui.setStatus("omni", "OmniRoute sync failed");
+				sessionCtx?.ui.notify(
+					`OmniRoute auto-sync failed: ${(error as Error).message}. Retry with /omni sync.`,
+					"warning",
+				);
+			});
+		}, interval);
 	}
 
 	// On load: re-register from existing models.json (no network call)
 	reloadProviderFromModelsJson(pi, agentHome, config);
 
 	pi.on("session_start", async (_event: any, ctx: any) => {
+		sessionCtx = ctx;
 		config = loadConfig(agentHome);
 		if (!existsSync(configPath(agentHome)) && !process.env.OMNIROUTE_URL) {
 			ctx.ui.setStatus("omni", "OmniRoute unconfigured");
@@ -575,16 +657,30 @@ export async function createOmniExtension(pi: OmniPI, opts: AgentHomeOptions): P
 		}
 		const ok = await checkHealth(agentHome, config, "session_start");
 		ctx.ui.setStatus("omni", ok ? undefined : "OmniRoute unreachable");
-		if (!ok) ctx.ui.notify(`OmniRoute unreachable at ${config.serverUrl}. Run /omni sync after reconnecting.`, "warning");
+		if (!ok) {
+			ctx.ui.notify(
+				`OmniRoute unreachable at ${config.serverUrl}. Run /omni sync after reconnecting.`,
+				"warning",
+			);
+		} else if (sanitizeAutoSyncIntervalMs(config.autoSyncIntervalMs) > 0) {
+			// Auto-discovery on session start when background sync is enabled.
+			// Disable with `/omni autosync off` (manual `/omni sync` still works).
+			void sync(ctx, { quiet: false }).catch((error) => {
+				ctx.ui.notify(`OmniRoute startup sync failed: ${(error as Error).message}`, "warning");
+			});
+		}
 		if (healthTimer) clearInterval(healthTimer);
 		healthTimer = setInterval(async () => {
 			ctx.ui.setStatus("omni", (await checkHealth(agentHome, loadConfig(agentHome), "interval")) ? undefined : "OmniRoute unreachable");
 		}, 60_000);
+		startAutoSync(ctx);
 	});
 
 	pi.on("session_shutdown", () => {
 		if (healthTimer) clearInterval(healthTimer);
 		healthTimer = undefined;
+		stopAutoSync();
+		sessionCtx = undefined;
 	});
 
 	pi.on("model_select", async (event: any, ctx: any) => {
@@ -629,9 +725,9 @@ export async function createOmniExtension(pi: OmniPI, opts: AgentHomeOptions): P
 	});
 
 	pi.registerCommand("omni", {
-		description: "OmniRoute: /omni [setup|sync|models|test|dashboard|config|log|help]",
+		description: "OmniRoute: /omni [setup|sync|models|test|dashboard|config|log|autosync|help]",
 		getArgumentCompletions(prefix: string) {
-			return ["setup", "sync", "models", "test", "dashboard", "config", "log", "help"]
+			return ["setup", "sync", "models", "test", "dashboard", "config", "log", "autosync", "help"]
 				.filter((v) => v.startsWith(prefix))
 				.map((v) => ({ value: v, label: v }));
 		},
@@ -697,7 +793,73 @@ export async function createOmniExtension(pi: OmniPI, opts: AgentHomeOptions): P
 							`Configured: ${existsSync(configPath(agentHome)) ? "yes" : "no"}`,
 							`Server:   ${config.serverUrl}`,
 							`Provider: ${config.providerName}`,
+							`Auto-sync: ${formatAutoSync(config.autoSyncIntervalMs)}`,
+							`Last sync: ${lastSyncAt ?? "not yet this session"}` +
+								(lastSyncCount ? ` (${lastSyncCount} models)` : ""),
 						].join("\n"),
+						"info",
+					);
+				}
+
+				if (sub === "autosync") {
+					const arg = (rest[0] || "status").toLowerCase();
+					if (arg === "status" || arg === "") {
+						return ctx.ui.notify(
+							[
+								`Auto-sync: ${formatAutoSync(config.autoSyncIntervalMs)}`,
+								`Active:    ${autoSyncTimer ? "yes" : "no (starts with session)"}`,
+								`Last sync: ${lastSyncAt ?? "not yet this session"}`,
+							].join("\n"),
+							"info",
+						);
+					}
+					if (arg === "off" || arg === "disable" || arg === "0") {
+						const next = sanitizeConfig({ ...config, autoSyncIntervalMs: 0 });
+						saveConfig(agentHome, next);
+						config = next;
+						stopAutoSync();
+						return ctx.ui.notify("OmniRoute auto-sync disabled. Manual /omni sync still works.", "info");
+					}
+					if (arg === "on" || arg === "enable" || arg === "default") {
+						const next = sanitizeConfig({
+							...config,
+							autoSyncIntervalMs: DEFAULT_AUTO_SYNC_INTERVAL_MS,
+						});
+						saveConfig(agentHome, next);
+						config = next;
+						startAutoSync(ctx);
+						// Immediate refresh when re-enabled.
+						await sync(ctx, { quiet: false });
+						return ctx.ui.notify(
+							`OmniRoute auto-sync enabled (${formatAutoSync(next.autoSyncIntervalMs)}).`,
+							"info",
+						);
+					}
+					// Treat as milliseconds or seconds shorthand (e.g. 300000 or 5m/300s)
+					let ms: number | null = null;
+					if (/^\d+$/.test(arg)) {
+						ms = Number(arg);
+						// values under 1000 are treated as seconds for convenience
+						if (ms > 0 && ms < 1000) ms = ms * 1000;
+					} else {
+						const m = arg.match(/^(\d+)(ms|s|m|h)$/);
+						if (m) {
+							const n = Number(m[1]);
+							ms = m[2] === "ms" ? n : m[2] === "s" ? n * 1000 : m[2] === "m" ? n * 60_000 : n * 3_600_000;
+						}
+					}
+					if (ms === null) {
+						return ctx.ui.notify(
+							"Usage: /omni autosync [status|on|off|<ms>|<Ns|Nm|Nh>]",
+							"warning",
+						);
+					}
+					const next = sanitizeConfig({ ...config, autoSyncIntervalMs: ms });
+					saveConfig(agentHome, next);
+					config = next;
+					startAutoSync(ctx);
+					return ctx.ui.notify(
+						`OmniRoute auto-sync set to ${formatAutoSync(next.autoSyncIntervalMs)}.`,
 						"info",
 					);
 				}
@@ -708,4 +870,15 @@ export async function createOmniExtension(pi: OmniPI, opts: AgentHomeOptions): P
 			}
 		},
 	});
+}
+
+/** One-shot helper for installers / external sync scripts. */
+export async function syncOmniModelsForAgentHome(
+	pi: OmniPI,
+	opts: AgentHomeOptions,
+): Promise<number> {
+	const agentHome = resolveAgentHome(opts);
+	const config = loadConfig(agentHome);
+	const models = await registerOmniProvider(pi, agentHome, config);
+	return models.length;
 }

--- a/test/shared.test.ts
+++ b/test/shared.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { createOmniExtension } from "../shared.ts";
+import { createOmniExtension, sanitizeAutoSyncIntervalMs, sanitizeConfig } from "../shared.ts";
 
 test("normalizes legacy Pi catalog API identifiers when reloading models.json", async () => {
   const agentHome = mkdtempSync(join(tmpdir(), "omniroute-agent-extension-test-"));
@@ -62,6 +62,63 @@ test("normalizes legacy Pi catalog API identifiers when reloading models.json", 
       cacheRead: 0,
       cacheWrite: 0,
     });
+  } finally {
+    if (previousHome === undefined) delete process.env[envName];
+    else process.env[envName] = previousHome;
+    rmSync(agentHome, { recursive: true, force: true });
+  }
+});
+
+test("sanitizeAutoSyncIntervalMs defaults and clamps", () => {
+  assert.equal(sanitizeAutoSyncIntervalMs(undefined), 300_000);
+  assert.equal(sanitizeAutoSyncIntervalMs(0), 0);
+  assert.equal(sanitizeAutoSyncIntervalMs(30_000), 60_000); // min 60s
+  assert.equal(sanitizeAutoSyncIntervalMs(120_000), 120_000);
+  assert.equal(sanitizeAutoSyncIntervalMs("nope"), 300_000);
+});
+
+test("sanitizeConfig accepts autoSyncIntervalMs and env override", () => {
+  const previous = process.env.OMNIROUTE_AUTO_SYNC_INTERVAL_MS;
+  try {
+    delete process.env.OMNIROUTE_AUTO_SYNC_INTERVAL_MS;
+    const cfg = sanitizeConfig({
+      serverUrl: "https://omniroute.example",
+      apiKey: "k",
+      providerName: "omni",
+      autoSyncIntervalMs: 0,
+    });
+    assert.equal(cfg.autoSyncIntervalMs, 0);
+
+    process.env.OMNIROUTE_AUTO_SYNC_INTERVAL_MS = "180000";
+    const cfgEnv = sanitizeConfig({
+      serverUrl: "https://omniroute.example",
+      apiKey: "k",
+      providerName: "omni",
+    });
+    assert.equal(cfgEnv.autoSyncIntervalMs, 180_000);
+  } finally {
+    if (previous === undefined) delete process.env.OMNIROUTE_AUTO_SYNC_INTERVAL_MS;
+    else process.env.OMNIROUTE_AUTO_SYNC_INTERVAL_MS = previous;
+  }
+});
+
+test("registers /omni autosync command", async () => {
+  const agentHome = mkdtempSync(join(tmpdir(), "omniroute-agent-extension-autosync-"));
+  const envName = "OMNIROUTE_TEST_HOME_AUTOSYNC";
+  const previousHome = process.env[envName];
+  process.env[envName] = agentHome;
+  const commands: string[] = [];
+  const pi = {
+    registerProvider() {},
+    registerTool() {},
+    registerCommand(name: string) {
+      commands.push(name);
+    },
+    on() {},
+  };
+  try {
+    await createOmniExtension(pi, { homeEnvVar: envName, defaultHome: agentHome });
+    assert.ok(commands.includes("omni"));
   } finally {
     if (previousHome === undefined) delete process.env[envName];
     else process.env[envName] = previousHome;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "target": "ES2022",
     "types": ["node"]
   },
-  "include": ["shared.ts", "omp.ts", "pi.ts", "test/**/*.ts"]
+  "include": ["shared.ts", "omp.ts", "pi.ts", "scripts/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
Fixes #12. Bump to 3.2.0 with session-start and interval catalog autosync. Install/docs stay on this parent repo, not a vendor fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic model catalog synchronization at session start and configurable intervals.
  * Added `/omni autosync` controls for viewing status, enabling/disabling sync, and setting intervals.
  * Added a one-time catalog synchronization command for setup and maintenance.

* **Documentation**
  * Updated setup, architecture, development, and testing guidance for autosync behavior.

* **Maintenance**
  * Updated the release version to 3.2.0.
  * Expanded test coverage for autosync configuration and command registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->