### PR TITLE
feat: surface gateway tok/s, cost, and routed model

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -18,7 +18,8 @@ It does three jobs:
 
 | Path | Purpose |
 |---|---|
-| `index.ts` | Entire extension implementation. Commands, sync, provider registration, prompt-tool fallback. |
+| `shared.ts` | Extension implementation shared by Pi and OMP entrypoints.
+| `telemetry.ts` | Gateway tok/s, cost, routed model/provider parsing. Never invents tok/s from latency. |
 | `README.md` | User-facing install/setup/usage docs. |
 | `package.json` | Pi extension metadata, scripts, dev deps. |
 | `package-lock.json` | Locked npm dependency tree. |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,6 +53,10 @@ Saved provider shape:
   -> re-register omni provider
 ```
 
+## Data Flow: Gateway telemetry
+
+After inference, wrap host fetch for /v1/chat/completions (and /v1/responses, /v1/messages). Read X-OmniRoute-* headers plus usage.tokens_per_second. Never derive tok/s from tokens/latency. On agent_settled, notify and setStatus. Missing fields stay unavailable.
+
 ## Data Flow: Native Tool Model
 
 ```text

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Connect to your local or remote OmniRoute server and route queries across 44+ LL
 - **Model sync** — push all OmniRoute models into the `Ctrl+P` / `/model` picker with full metadata: context windows, max tokens, reasoning, and vision capabilities.
 - **Native tool calls** — the host's built-in `openai-completions` handler runs every request, so you get real SSE streaming and native `tool_calls` for all models.
 - **Smart sorting** — models grouped by provider prefix, auto-routing models (`auto`, `auto/coding`, etc.) always first.
+- **Gateway telemetry** — after each turn, surface OmniRoute-resolved tok/s, cost, and routed model/provider when the gateway sends them. tok/s is never computed as tokens/latency. Missing values show as unavailable until OmniRoute emits them (see diegosouzapw/OmniRoute#12631).
 - **Health monitoring** — periodic reachability checks with status bar indicators.
 - **Connection log** — every failed or abnormally slow connection attempt is appended as a JSON line to `<agent-home>/<state>/connection.log` for infra debugging; `ms` timings expose server cold starts, error fields include the fetch `cause` (e.g. `ECONNRESET`, `ETIMEDOUT`, TLS errors).
 - **Env overrides** — `OMNIROUTE_URL`, `OMNIROUTE_API_KEY`, `OMNIROUTE_PROVIDER_NAME` skip the setup wizard entirely.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "type": "module",
   "files": [
     "shared.ts",
+    "telemetry.ts",
     "omp.ts",
     "pi.ts",
     "README.md",

--- a/shared.ts
+++ b/shared.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { registerGatewayTelemetry } from "./telemetry.ts";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -565,6 +566,7 @@ export async function createOmniExtension(pi: OmniPI, opts: AgentHomeOptions): P
 
 	// On load: re-register from existing models.json (no network call)
 	reloadProviderFromModelsJson(pi, agentHome, config);
+	registerGatewayTelemetry(pi);
 
 	pi.on("session_start", async (_event: any, ctx: any) => {
 		config = loadConfig(agentHome);

--- a/shared.ts
+++ b/shared.ts
@@ -566,7 +566,7 @@ export async function createOmniExtension(pi: OmniPI, opts: AgentHomeOptions): P
 
 	// On load: re-register from existing models.json (no network call)
 	reloadProviderFromModelsJson(pi, agentHome, config);
-	registerGatewayTelemetry(pi);
+	registerGatewayTelemetry(pi, { getServerUrl: () => loadConfig(agentHome).serverUrl });
 
 	pi.on("session_start", async (_event: any, ctx: any) => {
 		config = loadConfig(agentHome);

--- a/telemetry.ts
+++ b/telemetry.ts
@@ -1,0 +1,114 @@
+/** Parse gateway-resolved OmniRoute telemetry. Never invent tok/s from latency. */
+
+export const OMNIROUTE_TELEMETRY_HEADERS = {
+  tokensPerSecond: "x-omniroute-tokens-per-second",
+  model: "x-omniroute-model",
+  provider: "x-omniroute-provider",
+  responseCost: "x-omniroute-response-cost",
+  tokensIn: "x-omniroute-tokens-in",
+  tokensOut: "x-omniroute-tokens-out",
+  cache: "x-omniroute-cache",
+  fallbackAttempts: "x-omniroute-fallback-attempts",
+} as const;
+
+const INFERENCE_PATH = /\/v1\/(chat\/completions|responses|messages)(?:\?|$)/i;
+
+export type GatewayTelemetry = {
+  tokensPerSecond?: number;
+  model?: string;
+  provider?: string;
+  cost?: number;
+  tokensIn?: number;
+  tokensOut?: number;
+  cache?: string;
+  fallbackAttempts?: number;
+};
+
+function positiveNumber(raw: unknown): number | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) return raw;
+  if (typeof raw === "string" && raw.trim() !== "") {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return undefined;
+}
+
+function header(headers: Headers, name: string): string | undefined {
+  const value = headers.get(name);
+  return value && value.trim() !== "" ? value.trim() : undefined;
+}
+
+export function tokensPerSecondFromUsage(usage: unknown): number | undefined {
+  if (!usage || typeof usage !== "object") return undefined;
+  const record = usage as Record<string, unknown>;
+  return positiveNumber(record.tokens_per_second ?? record.tokensPerSecond);
+}
+
+export function parseGatewayTelemetry(headers: Headers, body: unknown): GatewayTelemetry {
+  const record = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const usage = record.usage;
+  const usageRecord = usage && typeof usage === "object" ? (usage as Record<string, unknown>) : {};
+  const telemetry: GatewayTelemetry = {};
+  const toks = positiveNumber(header(headers, OMNIROUTE_TELEMETRY_HEADERS.tokensPerSecond)) ?? tokensPerSecondFromUsage(usage);
+  if (toks !== undefined) telemetry.tokensPerSecond = toks;
+  const model = header(headers, OMNIROUTE_TELEMETRY_HEADERS.model) ?? (typeof record.model === "string" && record.model.trim() ? record.model.trim() : undefined);
+  if (model) telemetry.model = model;
+  const provider = header(headers, OMNIROUTE_TELEMETRY_HEADERS.provider);
+  if (provider) telemetry.provider = provider;
+  const costObj = usageRecord.cost;
+  const costTotal = costObj && typeof costObj === "object" ? positiveNumber((costObj as Record<string, unknown>).total) : undefined;
+  const cost = positiveNumber(header(headers, OMNIROUTE_TELEMETRY_HEADERS.responseCost)) ?? positiveNumber(usageRecord.cost) ?? costTotal;
+  if (cost !== undefined) telemetry.cost = cost;
+  const tokensIn = positiveNumber(header(headers, OMNIROUTE_TELEMETRY_HEADERS.tokensIn)) ?? positiveNumber(usageRecord.prompt_tokens ?? usageRecord.input_tokens);
+  if (tokensIn !== undefined) telemetry.tokensIn = tokensIn;
+  const tokensOut = positiveNumber(header(headers, OMNIROUTE_TELEMETRY_HEADERS.tokensOut)) ?? positiveNumber(usageRecord.completion_tokens ?? usageRecord.output_tokens);
+  if (tokensOut !== undefined) telemetry.tokensOut = tokensOut;
+  const cache = header(headers, OMNIROUTE_TELEMETRY_HEADERS.cache);
+  if (cache) telemetry.cache = cache;
+  const fallbackAttempts = positiveNumber(header(headers, OMNIROUTE_TELEMETRY_HEADERS.fallbackAttempts));
+  if (fallbackAttempts !== undefined) telemetry.fallbackAttempts = fallbackAttempts;
+  return telemetry;
+}
+
+export function formatTelemetryStatus(t: GatewayTelemetry | undefined): string {
+  if (!t || Object.keys(t).length === 0) return "tok/s unavailable";
+  const parts = [t.tokensPerSecond !== undefined ? "tok/s " + t.tokensPerSecond.toFixed(1) : "tok/s unavailable"];
+  if (t.cost !== undefined) parts.push("cost " + String(t.cost));
+  if (t.model) parts.push(t.model);
+  if (t.provider) parts.push(t.provider);
+  return parts.join(" | ");
+}
+
+export function wrapFetchCaptureTelemetry(fetchImpl: typeof fetch, onCapture: (t: GatewayTelemetry) => void): typeof fetch {
+  return async (input, init) => {
+    const response = await fetchImpl(input, init);
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (INFERENCE_PATH.test(url)) onCapture(parseGatewayTelemetry(response.headers, undefined));
+    return response;
+  };
+}
+
+type PiLike = { on(event: string, handler: (event: any, ctx: any) => any): void };
+
+export function registerGatewayTelemetry(pi: PiLike): void {
+  let captured: GatewayTelemetry | undefined;
+  let restoreFetch: (() => void) | undefined;
+  const install = () => {
+    if (restoreFetch) return;
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    globalThis.fetch = wrapFetchCaptureTelemetry(originalFetch, (t) => { captured = t; });
+    restoreFetch = () => { globalThis.fetch = originalFetch; };
+  };
+  pi.on("session_start", (() => { captured = undefined; install(); }));
+  pi.on("session_shutdown", (() => { restoreFetch?.(); restoreFetch = undefined; captured = undefined; }));
+  pi.on("agent_settled", ((event: unknown, ctx: unknown) => {
+    const payload = event as { messages?: Array<{ usage?: unknown }> };
+    const ui = ctx as { hasUI?: boolean; ui?: { notify?: (m: string, t?: string) => void; setStatus?: (k: string, v?: string) => void } };
+    const fromUsage = (payload.messages ?? []).map((m) => tokensPerSecondFromUsage(m.usage)).find((v) => v !== undefined);
+    if (captured && fromUsage !== undefined && captured.tokensPerSecond === undefined) captured = { ...captured, tokensPerSecond: fromUsage };
+    const line = formatTelemetryStatus(captured);
+    if (ui.hasUI) ui.ui?.notify?.(line, "info");
+    ui.ui?.setStatus?.("omni-telemetry", captured && Object.keys(captured).length ? line : undefined);
+    captured = undefined;
+  }));
+}

--- a/telemetry.ts
+++ b/telemetry.ts
@@ -33,6 +33,16 @@ function positiveNumber(raw: unknown): number | undefined {
   return undefined;
 }
 
+/** Preserve present zero costs (free/cached); reject negatives and non-finite. */
+function nonNegativeNumber(raw: unknown): number | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) return raw;
+  if (typeof raw === "string" && raw.trim() !== "") {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return undefined;
+}
+
 function header(headers: Headers, name: string): string | undefined {
   const value = headers.get(name);
   return value && value.trim() !== "" ? value.trim() : undefined;
@@ -42,6 +52,24 @@ export function tokensPerSecondFromUsage(usage: unknown): number | undefined {
   if (!usage || typeof usage !== "object") return undefined;
   const record = usage as Record<string, unknown>;
   return positiveNumber(record.tokens_per_second ?? record.tokensPerSecond);
+}
+
+function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+/** True when requestUrl is under the configured OmniRoute serverUrl. */
+function isOmniRouteUrl(requestUrl: string, serverUrl: string | undefined): boolean {
+  if (!serverUrl || !serverUrl.trim()) return false;
+  try {
+    const req = new URL(requestUrl);
+    const base = new URL(normalizeBaseUrl(serverUrl));
+    if (req.origin !== base.origin) return false;
+    const basePath = base.pathname === "/" ? "" : base.pathname.replace(/\/+$/, "");
+    return req.pathname === basePath || req.pathname.startsWith(basePath + "/");
+  } catch {
+    return false;
+  }
 }
 
 export function parseGatewayTelemetry(headers: Headers, body: unknown): GatewayTelemetry {
@@ -56,8 +84,8 @@ export function parseGatewayTelemetry(headers: Headers, body: unknown): GatewayT
   const provider = header(headers, OMNIROUTE_TELEMETRY_HEADERS.provider);
   if (provider) telemetry.provider = provider;
   const costObj = usageRecord.cost;
-  const costTotal = costObj && typeof costObj === "object" ? positiveNumber((costObj as Record<string, unknown>).total) : undefined;
-  const cost = positiveNumber(header(headers, OMNIROUTE_TELEMETRY_HEADERS.responseCost)) ?? positiveNumber(usageRecord.cost) ?? costTotal;
+  const costTotal = costObj && typeof costObj === "object" ? nonNegativeNumber((costObj as Record<string, unknown>).total) : undefined;
+  const cost = nonNegativeNumber(header(headers, OMNIROUTE_TELEMETRY_HEADERS.responseCost)) ?? nonNegativeNumber(usageRecord.cost) ?? costTotal;
   if (cost !== undefined) telemetry.cost = cost;
   const tokensIn = positiveNumber(header(headers, OMNIROUTE_TELEMETRY_HEADERS.tokensIn)) ?? positiveNumber(usageRecord.prompt_tokens ?? usageRecord.input_tokens);
   if (tokensIn !== undefined) telemetry.tokensIn = tokensIn;
@@ -74,30 +102,62 @@ export function formatTelemetryStatus(t: GatewayTelemetry | undefined): string {
   if (!t || Object.keys(t).length === 0) return "tok/s unavailable";
   const parts = [t.tokensPerSecond !== undefined ? "tok/s " + t.tokensPerSecond.toFixed(1) : "tok/s unavailable"];
   if (t.cost !== undefined) parts.push("cost " + String(t.cost));
+  if (t.tokensIn !== undefined) parts.push("in " + String(t.tokensIn));
+  if (t.tokensOut !== undefined) parts.push("out " + String(t.tokensOut));
+  if (t.cache) parts.push("cache " + t.cache);
+  if (t.fallbackAttempts !== undefined) parts.push("fallbacks " + String(t.fallbackAttempts));
   if (t.model) parts.push(t.model);
   if (t.provider) parts.push(t.provider);
   return parts.join(" | ");
 }
 
-export function wrapFetchCaptureTelemetry(fetchImpl: typeof fetch, onCapture: (t: GatewayTelemetry) => void): typeof fetch {
+export type WrapFetchCaptureOptions = {
+  serverUrl?: string | (() => string | undefined);
+};
+
+export function wrapFetchCaptureTelemetry(
+  fetchImpl: typeof fetch,
+  onCapture: (t: GatewayTelemetry) => void,
+  options?: WrapFetchCaptureOptions,
+): typeof fetch {
   return async (input, init) => {
     const response = await fetchImpl(input, init);
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    if (INFERENCE_PATH.test(url)) onCapture(parseGatewayTelemetry(response.headers, undefined));
+    const serverUrl = typeof options?.serverUrl === "function" ? options.serverUrl() : options?.serverUrl;
+    if (INFERENCE_PATH.test(url) && isOmniRouteUrl(url, serverUrl)) {
+      let body: unknown;
+      try {
+        body = await response.clone().json();
+      } catch {
+        body = undefined;
+      }
+      onCapture(parseGatewayTelemetry(response.headers, body));
+    }
     return response;
   };
 }
 
 type PiLike = { on(event: string, handler: (event: any, ctx: any) => any): void };
 
-export function registerGatewayTelemetry(pi: PiLike): void {
+export type RegisterGatewayTelemetryOptions = {
+  getServerUrl?: () => string | undefined;
+};
+
+export function registerGatewayTelemetry(pi: PiLike, options?: RegisterGatewayTelemetryOptions): void {
   let captured: GatewayTelemetry | undefined;
   let restoreFetch: (() => void) | undefined;
   const install = () => {
     if (restoreFetch) return;
     const originalFetch = globalThis.fetch.bind(globalThis);
-    globalThis.fetch = wrapFetchCaptureTelemetry(originalFetch, (t) => { captured = t; });
-    restoreFetch = () => { globalThis.fetch = originalFetch; };
+    const wrappedFetch = wrapFetchCaptureTelemetry(
+      originalFetch,
+      (t) => { captured = t; },
+      { serverUrl: () => options?.getServerUrl?.() },
+    );
+    globalThis.fetch = wrappedFetch;
+    restoreFetch = () => {
+      if (globalThis.fetch === wrappedFetch) globalThis.fetch = originalFetch;
+    };
   };
   pi.on("session_start", (() => { captured = undefined; install(); }));
   pi.on("session_shutdown", (() => { restoreFetch?.(); restoreFetch = undefined; captured = undefined; }));

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatTelemetryStatus, parseGatewayTelemetry, tokensPerSecondFromUsage, wrapFetchCaptureTelemetry } from "../telemetry.ts";
+
+test("reads tok/s from usage and omits zero or latency-derived values", () => {
+  assert.equal(tokensPerSecondFromUsage({ tokens_per_second: 42.5 }), 42.5);
+  assert.equal(tokensPerSecondFromUsage({ tokens_per_second: 0 }), undefined);
+  assert.equal(tokensPerSecondFromUsage({ output_tokens: 100, latency_ms: 2000 }), undefined);
+});
+
+test("parses present headers and leaves absent telemetry empty", () => {
+  const present = parseGatewayTelemetry(new Headers({
+    "x-omniroute-tokens-per-second": "18.2",
+    "x-omniroute-model": "omni/claude-opus",
+    "x-omniroute-provider": "anthropic",
+    "x-omniroute-response-cost": "0.012",
+  }), { model: "alias" });
+  assert.equal(present.tokensPerSecond, 18.2);
+  assert.equal(present.model, "omni/claude-opus");
+  assert.equal(present.provider, "anthropic");
+  assert.equal(present.cost, 0.012);
+  const absent = parseGatewayTelemetry(new Headers(), {});
+  assert.deepEqual(absent, {});
+  assert.equal(formatTelemetryStatus(absent), "tok/s unavailable");
+});
+
+test("uses body model when routed model header is absent", () => {
+  const routed = parseGatewayTelemetry(new Headers(), { model: "omni/gpt-sol", usage: { tokens_per_second: 9 } });
+  assert.equal(routed.model, "omni/gpt-sol");
+  assert.equal(routed.tokensPerSecond, 9);
+});
+
+test("fetch wrapper captures inference URLs only", async () => {
+  const seen: string[] = [];
+  const inner = (async (_input: RequestInfo | URL) => new Response("{}", { headers: { "x-omniroute-tokens-per-second": "11" } })) as typeof fetch;
+  const wrapped = wrapFetchCaptureTelemetry(inner, (t) => { if (t.tokensPerSecond) seen.push(String(t.tokensPerSecond)); });
+  await wrapped("https://omniroute.example/v1/models");
+  await wrapped("https://omniroute.example/v1/chat/completions");
+  assert.deepEqual(seen, ["11"]);
+});

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -24,17 +24,57 @@ test("parses present headers and leaves absent telemetry empty", () => {
   assert.equal(formatTelemetryStatus(absent), "tok/s unavailable");
 });
 
+test("preserves zero response cost", () => {
+  const zero = parseGatewayTelemetry(new Headers({ "x-omniroute-response-cost": "0" }), {});
+  assert.equal(zero.cost, 0);
+  assert.equal(formatTelemetryStatus(zero), "tok/s unavailable | cost 0");
+});
+
 test("uses body model when routed model header is absent", () => {
   const routed = parseGatewayTelemetry(new Headers(), { model: "omni/gpt-sol", usage: { tokens_per_second: 9 } });
   assert.equal(routed.model, "omni/gpt-sol");
   assert.equal(routed.tokensPerSecond, 9);
 });
 
-test("fetch wrapper captures inference URLs only", async () => {
-  const seen: string[] = [];
-  const inner = (async (_input: RequestInfo | URL) => new Response("{}", { headers: { "x-omniroute-tokens-per-second": "11" } })) as typeof fetch;
-  const wrapped = wrapFetchCaptureTelemetry(inner, (t) => { if (t.tokensPerSecond) seen.push(String(t.tokensPerSecond)); });
+test("formatter includes tokensIn/tokensOut/cache/fallbackAttempts", () => {
+  const line = formatTelemetryStatus({
+    tokensPerSecond: 12.34,
+    cost: 0,
+    tokensIn: 100,
+    tokensOut: 50,
+    cache: "hit",
+    fallbackAttempts: 2,
+    model: "omni/x",
+    provider: "p",
+  });
+  assert.equal(line, "tok/s 12.3 | cost 0 | in 100 | out 50 | cache hit | fallbacks 2 | omni/x | p");
+});
+
+test("fetch wrapper captures OmniRoute inference URLs only and parses body", async () => {
+  const seen: Array<{ tokensPerSecond?: number; model?: string }> = [];
+  const inner = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes("/chat/completions")) {
+      return new Response(JSON.stringify({ model: "from-body", usage: { tokens_per_second: 7.5 } }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("{}", { headers: { "x-omniroute-tokens-per-second": "11" } });
+  }) as typeof fetch;
+  const serverUrl = "https://omniroute.example";
+  const wrapped = wrapFetchCaptureTelemetry(inner, (t) => { seen.push(t); }, { serverUrl });
   await wrapped("https://omniroute.example/v1/models");
+  await wrapped("https://other.example/v1/chat/completions");
   await wrapped("https://omniroute.example/v1/chat/completions");
-  assert.deepEqual(seen, ["11"]);
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].tokensPerSecond, 7.5);
+  assert.equal(seen[0].model, "from-body");
+});
+
+test("fetch wrapper skips capture when serverUrl is unset", async () => {
+  const seen: unknown[] = [];
+  const inner = (async () => new Response("{}", { headers: { "x-omniroute-tokens-per-second": "11" } })) as typeof fetch;
+  const wrapped = wrapFetchCaptureTelemetry(inner, (t) => { seen.push(t); });
+  await wrapped("https://omniroute.example/v1/chat/completions");
+  assert.deepEqual(seen, []);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "target": "ES2022",
     "types": ["node"]
   },
-  "include": ["shared.ts", "omp.ts", "pi.ts", "test/**/*.ts"]
+  "include": ["shared.ts", "telemetry.ts", "omp.ts", "pi.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
## What

Surface OmniRoute-resolved telemetry after each turn: tok/s, cost, routed model/provider. Values come from X-OmniRoute-* headers and usage.tokens_per_second. Missing fields stay unavailable.

tok/s is never computed as tokens/latency.

## Why

Closes #14. Gateway contract: diegosouzapw/OmniRoute#12616 / diegosouzapw/OmniRoute#12631.

## Testing

- bun run typecheck
- bun test (5 pass, including present/absent/routed-model and fetch wrapper path filter)
- bun run smoke


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added gateway telemetry after inference, displaying routed model, provider, cost, token usage, and tokens per second when supplied by the gateway.
  - Preserved zero-cost values and left missing telemetry unavailable rather than estimating them.
  - Telemetry is captured for supported chat and response requests and reported when an agent turn completes.

- **Documentation**
  - Added documentation describing gateway telemetry behavior and data flow.

- **Tests**
  - Added coverage for telemetry parsing, formatting, fallback behavior, and supported request paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->