### PR TITLE
feat: add Prime Agent compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Connect to your local or remote OmniRoute server, browse models, manage combos, 
 
 ## Installation
 
+### Prime Agent
+
+Prime Agent is a Pi-derived agent with a different configuration directory and
+stricter provider validation. This package supports both Pi and Prime Agent.
+
+```bash
+prime-agent package install git:github.com/alfred-rootson/omniroute-pi-ext-integration
+```
+
+After installation, restart Prime Agent and run `/omni setup`, then `/omni sync`.
+
+
 Install the package directly from NPM:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-# OmniRoute Pi Extension
+# OmniRoute Agent Extension
 
 [![npm version](https://img.shields.io/npm/v/omniroute-pi-ext-integration.svg?style=flat-square)](https://www.npmjs.com/package/omniroute-pi-ext-integration)
 [![npm downloads](https://img.shields.io/npm/dm/omniroute-pi-ext-integration.svg?style=flat-square)](https://www.npmjs.com/package/omniroute-pi-ext-integration)
 
-A seamless [Pi Coding Agent](https://github.com/earendil-works/pi/tree/main/packages/coding-agent) extension that brings [OmniRoute](https://github.com/diegosouzapw/OmniRoute) — the ultimate AI gateway — directly into your editor environment.
+A shared OmniRoute integration for **Pi Coding Agent**, **Oh My Pi**, and
+**Prime Agent**. The npm package remains named `omniroute-pi-ext-integration`
+for compatibility; the GitHub repository is `omniroute-agent-extension`.
 
-Connect to your local or remote OmniRoute server, browse models, manage combos, check quotas, and intelligently route your Pi queries across 44+ LLM providers.
+Connect to a local or remote OmniRoute server, browse models, manage combos,
+check quotas, and route queries across 44+ LLM providers.
 
 ## Features
 
@@ -23,41 +26,52 @@ Connect to your local or remote OmniRoute server, browse models, manage combos, 
 
 ### Prime Agent
 
-Prime Agent is a Pi-derived agent with a different configuration directory and
-stricter provider validation. This package supports both Pi and Prime Agent.
+Prime Agent is supported through its Pi-compatible package system. Install the
+Prime-compatible fork/branch from this repository at the reviewed commit:
 
 ```bash
-prime-agent package install git:github.com/alfred-rootson/omniroute-pi-ext-integration
+prime-agent package install git:github.com/alfred-rootson/omniroute-agent-extension@d568da14bffa9281b7e6137e704a8a9812414c16
 ```
 
-After installation, restart Prime Agent and run `/omni setup`, then `/omni sync`.
+Restart Prime Agent, then run `/omni setup` followed by `/omni sync`.
+Prime Agent stores its catalog under `~/.prime/agent`; the extension creates
+that directory on first use.
 
+### Pi Coding Agent
 
-Install the package directly from NPM:
+Install the published npm package:
 
 ```bash
 pi install omniroute-pi-ext-integration
 ```
 
-Or install the latest development version directly from GitHub:
+Or install from the upstream repository:
 
 ```bash
-pi install git:github.com/md-riaz/omniroute-pi-ext-integration
+pi install git:github.com/md-riaz/omniroute-agent-extension
 ```
+
+### Oh My Pi
+
+Install the published package with Oh My Pi:
+
+```bash
+omp install omniroute-pi-ext-integration
+```
+
+Or install the upstream repository directly:
+
+```bash
+omp install git:github.com/md-riaz/omniroute-agent-extension
+```
+
 
 ## Getting Started
 
-1. **Start Pi:**
-   ```bash
-   pi
-   ```
-2. **Run Setup:** Once Pi starts, open the command palette and run:
-   ```bash
-   /omni setup
-   ```
-3. **Enter Credentials:** Enter your OmniRoute Server URL and API key when prompted. The key is collected before connectivity testing so protected `/v1/models` endpoints can be verified.
-4. **Sync Models:** Run `/omni sync` to populate the `Ctrl+P` list with all your provider models and combos.
-5. **Switch Models Normally:** Use `/model` as usual. No separate prompt-tools provider is needed.
+The `/omni` commands are available in all three supported agents. Start the
+agent you installed, run `/omni setup`, enter the OmniRoute URL and API key,
+then run `/omni sync` to populate the model picker.
+
 
 ## Prompt Tool Fallback
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Prime Agent is supported through its Pi-compatible package system. Install the
 Prime-compatible fork/branch from this repository at the reviewed commit:
 
 ```bash
-prime-agent package install git:github.com/alfred-rootson/omniroute-agent-extension@d568da14bffa9281b7e6137e704a8a9812414c16
+prime-agent package install git:github.com/alfred-rootson/omniroute-agent-extension@a393c55c583236a8c900ed40f074cde21eb85231
 ```
 
 Restart Prime Agent, then run `/omni setup` followed by `/omni sync`.

--- a/index.ts
+++ b/index.ts
@@ -34,13 +34,19 @@ const UNDERLYING_API = "openai-completions";
 
 /** Resolve the active agent's models.json path.
  * Prime Agent uses PRIME_AGENT_CODING_AGENT_DIR (~/.prime/agent), while
- * upstream Pi uses PI_HOME or ~/.pi/agent. Prefer Prime Agent's directory.
+ * upstream Pi uses PI_HOME or ~/.pi/agent. Preserve Pi's default when the
+ * launcher does not expose an explicit Prime Agent directory.
  */
 function modelsJsonPath(): string {
-	const dir = process.env.PRIME_AGENT_CODING_AGENT_DIR || process.env.PI_HOME;
-	return dir
-		? `${dir.replace(/\/$/, "")}/models.json`
-		: `${homedir()}/.prime/agent/models.json`;
+	const explicitDir = process.env.PRIME_AGENT_CODING_AGENT_DIR || process.env.PI_HOME;
+	if (explicitDir) return `${explicitDir.replace(/\/$/, "")}/models.json`;
+
+	// Prime Agent's bundled launcher path is the only reliable distinction when
+	// neither agent-specific override is set; ordinary Pi keeps ~/.pi/agent.
+	const launchedByPrime = process.argv.some((arg) => arg.includes("prime-agent"));
+	return launchedByPrime
+		? `${homedir()}/.prime/agent/models.json`
+		: `${homedir()}/.pi/agent/models.json`;
 }
 
 /** Ensure Prime Agent/Pi's configuration directory exists before I/O. */

--- a/index.ts
+++ b/index.ts
@@ -32,17 +32,39 @@ import { homedir } from "os";
 const OMNI_PROMPT_TOOLS_API = "omni-prompt-tools";
 const UNDERLYING_API = "openai-completions";
 
-/** Resolve Pi's models.json path; PI_HOME lets tests/custom installs point elsewhere. */
+/** Resolve the active agent's models.json path.
+ * Prime Agent uses PRIME_AGENT_CODING_AGENT_DIR (~/.prime/agent), while
+ * upstream Pi uses PI_HOME or ~/.pi/agent. Prefer Prime Agent's directory.
+ */
 function modelsJsonPath(): string {
-	return process.env.PI_HOME
-		? `${process.env.PI_HOME}/models.json`
-		: `${homedir()}/.pi/agent/models.json`;
+	const dir = process.env.PRIME_AGENT_CODING_AGENT_DIR || process.env.PI_HOME;
+	return dir
+		? `${dir.replace(/\/$/, "")}/models.json`
+		: `${homedir()}/.prime/agent/models.json`;
+}
+
+/** Ensure Prime Agent/Pi's configuration directory exists before I/O. */
+function ensureModelsDir(): void {
+	const fs = require("fs");
+	const path = require("path");
+	fs.mkdirSync(path.dirname(modelsJsonPath()), { recursive: true });
+}
+
+/** Read models.json, treating a first-run install as an empty config. */
+function readModelsConfig(): any {
+	const fs = require("fs");
+	ensureModelsDir();
+	try {
+		return JSON.parse(fs.readFileSync(modelsJsonPath(), "utf8"));
+	} catch (e: any) {
+		if (e?.code === "ENOENT") return {};
+		throw e;
+	}
 }
 
 /** Read raw models.json because custom metadata like tool_calling is not preserved by Pi's Model type. */
 function readModelsJson(): any {
-	const fs = require("fs");
-	return JSON.parse(fs.readFileSync(modelsJsonPath(), "utf8"));
+	return readModelsConfig();
 }
 
 /** Load OmniRoute base URL from models.json, falling back to local default before setup. */
@@ -74,6 +96,10 @@ function isOmniConfigured(): boolean {
 
 let OMNI_URL = getOmniUrl();
 let DASHBOARD_URL = OMNI_URL;
+// Capture Prime Agent's built-in OpenAI provider before registering `omni`.
+// Looking it up after registration can resolve back to our own streamSimple
+// handler and recurse indefinitely.
+let underlyingApiProvider: ReturnType<typeof getApiProvider> | undefined;
 
 /**
  * Register/refresh the omni provider with a custom stream handler.
@@ -89,12 +115,14 @@ function registerOmniProvider(pi: ExtensionAPI): void {
 			baseUrl: (provider.baseUrl || OMNI_URL).replace(/\/$/, ""),
 			// Pi/OpenAI SDK require a non-empty apiKey; OmniRoute may ignore this dummy for public/local setups.
 			apiKey: provider.apiKey || "omniroute-public",
-			api: OMNI_PROMPT_TOOLS_API,
+			// Prime Agent validates `api` against its built-in API registry. Keep the
+			// custom stream handler, but advertise the compatible built-in API.
+			api: UNDERLYING_API,
 			streamSimple: streamOmni,
 			models: (provider.models || []).map((model: any) => ({
 				id: model.id,
 				name: model.name || humanName(model.id),
-				api: OMNI_PROMPT_TOOLS_API,
+				api: UNDERLYING_API,
 				reasoning: model.reasoning ?? false,
 				thinkingLevelMap: model.thinkingLevelMap,
 				input: model.input || ["text"],
@@ -405,7 +433,7 @@ function streamWithPromptTools(
 				tools: [],
 			};
 
-			const provider = getApiProvider(UNDERLYING_API);
+			const provider = underlyingApiProvider;
 			if (!provider) throw new Error(`Underlying api "${UNDERLYING_API}" is not registered`);
 
 			const innerModel: Model<any> = { ...model, api: UNDERLYING_API };
@@ -478,7 +506,7 @@ function streamOmni(
 ): AssistantMessageEventStream {
 	if (shouldUsePromptTools(model)) return streamWithPromptTools(model, context, options);
 
-	const provider = getApiProvider(UNDERLYING_API);
+	const provider = underlyingApiProvider;
 	if (!provider) throw new Error(`Underlying api "${UNDERLYING_API}" is not registered`);
 	return provider.streamSimple({ ...model, api: UNDERLYING_API }, context, options);
 }
@@ -517,7 +545,7 @@ async function getAllModelsFromOmniRoute(): Promise<SyncedModel[]> {
 			id,
 			name: humanName(id),
 			owned_by: m.owned_by,
-			api: OMNI_PROMPT_TOOLS_API,
+			api: UNDERLYING_API,
 		};
 
 		if (isWebSyncedModel(id, m.name, m.owned_by, m.provider)) synced.tool_calling = false;
@@ -567,6 +595,7 @@ function humanName(id: string): string {
 
 export default function (pi: ExtensionAPI) {
 	let healthInterval: ReturnType<typeof setInterval> | undefined;
+	underlyingApiProvider = getApiProvider(UNDERLYING_API);
 	registerOmniProvider(pi);
 
 	pi.on("model_select", async (event: any, ctx: any) => {
@@ -640,7 +669,7 @@ export default function (pi: ExtensionAPI) {
 					const allModels = await getAllModelsFromOmniRoute();
 					const fs = require("fs");
 					const path = modelsJsonPath();
-					const config = JSON.parse(fs.readFileSync(path, "utf8"));
+					const config = readModelsConfig();
 
 					if (!config.providers?.omni) {
 						ctx.ui.notify(
@@ -670,6 +699,7 @@ export default function (pi: ExtensionAPI) {
 
 			if (sub === "setup") {
 				const fs = require("fs");
+				ensureModelsDir();
 				const path = modelsJsonPath();
 
 				const urlInput = await ctx.ui.input(
@@ -707,15 +737,11 @@ export default function (pi: ExtensionAPI) {
 				}
 
 				try {
-					let config: any = {};
-					try {
-						config = JSON.parse(fs.readFileSync(path, "utf8"));
-					} catch {}
-
+					let config: any = readModelsConfig();
 					if (!config.providers) config.providers = {};
 					config.providers.omni = {
 						baseUrl,
-						api: OMNI_PROMPT_TOOLS_API,
+						api: UNDERLYING_API,
 						apiKey: trimmedApiKey,
 						models: [],
 					};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniroute-pi-ext-integration",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniroute-pi-ext-integration",
-      "version": "2.0.0",
+      "version": "2.0.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute-pi-ext-integration",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Pi Coding Agent extension for OmniRoute — view combos, browse providers, and sync models with enriched metadata (context windows, max tokens, reasoning, and vision) to the Ctrl+P picker",
   "keywords": [
     "pi-package",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniroute-pi-ext-integration",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Pi Coding Agent extension for OmniRoute — view combos, browse providers, and sync models with enriched metadata (context windows, max tokens, reasoning, and vision) to the Ctrl+P picker",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary

Add compatibility for Prime Agent while preserving Pi behavior.

## Changes

- Resolve `models.json` using `PRIME_AGENT_CODING_AGENT_DIR`, `PI_HOME`, and Prime Agent's `~/.prime/agent` default.
- Create the agent directory on first run.
- Treat a missing first-run `models.json` as an empty configuration.
- Advertise `openai-completions` for Prime Agent provider validation while retaining the custom stream handler.
- Capture the built-in OpenAI provider before registering `omni` to avoid recursive `streamSimple` dispatch.
- Document Prime Agent installation and setup.

## Verification

- `npm run typecheck` passed.
- `npm run smoke` passed.
- Tested setup, model sync, model picker visibility, and real requests through Prime Agent.

The Prime Agent runtime is based on Pi but uses `~/.prime/agent` and stricter provider registration behavior. This PR keeps the package name and Pi support intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared installation and configuration guidance for Pi Coding Agent, Oh My Pi, and Prime Agent.
  - Added support for selecting the appropriate model configuration directory for Prime Agent and Pi-based environments.
  - Configuration directories are created automatically when needed.

- **Bug Fixes**
  - Improved handling of missing model configuration files.
  - Updated provider registration and setup to use the standard OpenAI-compatible API for broader compatibility.

- **Documentation**
  - Expanded installation and getting-started instructions for all supported agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->